### PR TITLE
Common interface for AddressBuilder/LenientAddressBuilder

### DIFF
--- a/dom/src/main/java/org/apache/james/mime4j/field/AddressListFieldImpl.java
+++ b/dom/src/main/java/org/apache/james/mime4j/field/AddressListFieldImpl.java
@@ -23,7 +23,7 @@ import org.apache.james.mime4j.codec.DecodeMonitor;
 import org.apache.james.mime4j.dom.FieldParser;
 import org.apache.james.mime4j.dom.address.AddressList;
 import org.apache.james.mime4j.dom.field.AddressListField;
-import org.apache.james.mime4j.field.address.AddressBuilder;
+import org.apache.james.mime4j.field.address.DefaultAddressBuilder;
 import org.apache.james.mime4j.field.address.ParseException;
 import org.apache.james.mime4j.stream.Field;
 
@@ -66,7 +66,7 @@ public class AddressListFieldImpl extends AbstractField implements AddressListFi
         String body = getBody();
 
         try {
-            addressList = AddressBuilder.DEFAULT.parseAddressList(body, monitor);
+            addressList = DefaultAddressBuilder.DEFAULT.parseAddressList(body, monitor);
         } catch (ParseException e) {
             parseException = e;
         }

--- a/dom/src/main/java/org/apache/james/mime4j/field/MailboxFieldImpl.java
+++ b/dom/src/main/java/org/apache/james/mime4j/field/MailboxFieldImpl.java
@@ -23,7 +23,7 @@ import org.apache.james.mime4j.codec.DecodeMonitor;
 import org.apache.james.mime4j.dom.FieldParser;
 import org.apache.james.mime4j.dom.address.Mailbox;
 import org.apache.james.mime4j.dom.field.MailboxField;
-import org.apache.james.mime4j.field.address.AddressBuilder;
+import org.apache.james.mime4j.field.address.DefaultAddressBuilder;
 import org.apache.james.mime4j.field.address.ParseException;
 import org.apache.james.mime4j.stream.Field;
 
@@ -65,7 +65,7 @@ public class MailboxFieldImpl extends AbstractField implements MailboxField {
         String body = getBody();
 
         try {
-            mailbox = AddressBuilder.DEFAULT.parseMailbox(body, monitor);
+            mailbox = DefaultAddressBuilder.DEFAULT.parseMailbox(body, monitor);
         } catch (ParseException e) {
             parseException = e;
         }

--- a/dom/src/main/java/org/apache/james/mime4j/field/MailboxListFieldImpl.java
+++ b/dom/src/main/java/org/apache/james/mime4j/field/MailboxListFieldImpl.java
@@ -23,7 +23,7 @@ import org.apache.james.mime4j.codec.DecodeMonitor;
 import org.apache.james.mime4j.dom.FieldParser;
 import org.apache.james.mime4j.dom.address.MailboxList;
 import org.apache.james.mime4j.dom.field.MailboxListField;
-import org.apache.james.mime4j.field.address.AddressBuilder;
+import org.apache.james.mime4j.field.address.DefaultAddressBuilder;
 import org.apache.james.mime4j.field.address.ParseException;
 import org.apache.james.mime4j.stream.Field;
 
@@ -65,7 +65,7 @@ public class MailboxListFieldImpl extends AbstractField implements MailboxListFi
         String body = getBody();
 
         try {
-            mailboxList = AddressBuilder.DEFAULT.parseAddressList(body, monitor).flatten();
+            mailboxList = DefaultAddressBuilder.DEFAULT.parseAddressList(body, monitor).flatten();
         } catch (ParseException e) {
             parseException = e;
         }

--- a/dom/src/main/java/org/apache/james/mime4j/field/address/AddressBuilder.java
+++ b/dom/src/main/java/org/apache/james/mime4j/field/address/AddressBuilder.java
@@ -25,10 +25,10 @@ import org.apache.james.mime4j.dom.address.Group;
 import org.apache.james.mime4j.dom.address.Mailbox;
 
 /**
- * Either a lenient {@link LenientAddressBuilder} or strict {@link AddressBuilder} builder for {@link Address} and its subclasses.
+ * Either a lenient {@link LenientAddressBuilder} or strict {@link DefaultAddressBuilder} builder for {@link Address} and its subclasses.
  * 
  */
-public interface SharedAddressBuilder {
+public interface AddressBuilder {
 
     /**
      * Parses the specified raw string into an address.
@@ -38,7 +38,7 @@ public interface SharedAddressBuilder {
      * @return an <code>Address</code> object for the specified string.
      * @throws ParseException if the raw string does not represent a single address.
      */
-    public abstract Address parseAddress(String rawAddressString) throws ParseException;
+    Address parseAddress(String rawAddressString) throws ParseException;
 
     /**
      * Parse the address list string, such as the value of a From, To, Cc, Bcc,
@@ -48,7 +48,7 @@ public interface SharedAddressBuilder {
      * @param rawAddressList
      *            string to parse.
      */
-    public abstract AddressList parseAddressList(String rawAddressList) throws ParseException;
+    AddressList parseAddressList(String rawAddressList) throws ParseException;
 
     /**
      * Parses the specified raw string into a mailbox address.
@@ -60,7 +60,7 @@ public interface SharedAddressBuilder {
      *             if the raw string does not represent a single mailbox
      *             address.
      */
-    public abstract Mailbox parseMailbox(String rawMailboxString) throws ParseException;
+    Mailbox parseMailbox(String rawMailboxString) throws ParseException;
 
     /**
      * Parses the specified raw string into a group address.
@@ -71,6 +71,6 @@ public interface SharedAddressBuilder {
      * @throws ParseException
      *             if the raw string does not represent a single group address.
      */
-    public abstract Group parseGroup(String rawGroupString) throws ParseException;
+    Group parseGroup(String rawGroupString) throws ParseException;
 
 }

--- a/dom/src/main/java/org/apache/james/mime4j/field/address/DefaultAddressBuilder.java
+++ b/dom/src/main/java/org/apache/james/mime4j/field/address/DefaultAddressBuilder.java
@@ -30,11 +30,11 @@ import org.apache.james.mime4j.dom.address.Mailbox;
 /**
  * Default (strict) builder for {@link Address} and its subclasses.
  */
-public class AddressBuilder implements SharedAddressBuilder {
+public class DefaultAddressBuilder implements AddressBuilder {
 
-    public static final AddressBuilder DEFAULT = new AddressBuilder();
+    public static final DefaultAddressBuilder DEFAULT = new DefaultAddressBuilder();
 
-    protected AddressBuilder() {
+    protected DefaultAddressBuilder() {
         super();
     }
 

--- a/dom/src/main/java/org/apache/james/mime4j/field/address/LenientAddressBuilder.java
+++ b/dom/src/main/java/org/apache/james/mime4j/field/address/LenientAddressBuilder.java
@@ -41,7 +41,7 @@ import org.apache.james.mime4j.util.ContentUtil;
  * Lenient (tolerant to non-critical format violations) builder for {@link Address}
  * and its subclasses.
  */
-public class LenientAddressBuilder implements SharedAddressBuilder {
+public class LenientAddressBuilder implements AddressBuilder {
 
     private static final int AT                = '@';
     private static final int OPENING_BRACKET   = '<';

--- a/dom/src/main/java/org/apache/james/mime4j/message/MessageBuilder.java
+++ b/dom/src/main/java/org/apache/james/mime4j/message/MessageBuilder.java
@@ -55,7 +55,7 @@ import org.apache.james.mime4j.dom.field.UnstructuredField;
 import org.apache.james.mime4j.field.DefaultFieldParser;
 import org.apache.james.mime4j.field.Fields;
 import org.apache.james.mime4j.field.LenientFieldParser;
-import org.apache.james.mime4j.field.address.AddressBuilder;
+import org.apache.james.mime4j.field.address.DefaultAddressBuilder;
 import org.apache.james.mime4j.io.InputStreams;
 import org.apache.james.mime4j.parser.MimeStreamParser;
 import org.apache.james.mime4j.stream.BodyDescriptorBuilder;
@@ -777,7 +777,7 @@ public class MessageBuilder extends AbstractEntityBuilder {
         if (mailbox == null) {
             removeFields(fieldName);
         } else {
-            setField(Fields.mailbox(fieldName, AddressBuilder.DEFAULT.parseMailbox(mailbox)));
+            setField(Fields.mailbox(fieldName, DefaultAddressBuilder.DEFAULT.parseMailbox(mailbox)));
         }
         return this;
     }
@@ -792,7 +792,7 @@ public class MessageBuilder extends AbstractEntityBuilder {
     }
 
     private MessageBuilder setMailboxList(String fieldName, String mailbox) throws ParseException {
-        return setMailboxList(fieldName, mailbox == null ? null : AddressBuilder.DEFAULT.parseMailbox(mailbox));
+        return setMailboxList(fieldName, mailbox == null ? null : DefaultAddressBuilder.DEFAULT.parseMailbox(mailbox));
     }
 
     private MessageBuilder setMailboxList(String fieldName, Mailbox... mailboxes) {
@@ -805,7 +805,7 @@ public class MessageBuilder extends AbstractEntityBuilder {
         } else {
             List<Mailbox> list = new ArrayList<Mailbox>();
             for (String mailbox: mailboxes) {
-                list.add(AddressBuilder.DEFAULT.parseMailbox(mailbox));
+                list.add(DefaultAddressBuilder.DEFAULT.parseMailbox(mailbox));
             }
             return list;
         }
@@ -834,7 +834,7 @@ public class MessageBuilder extends AbstractEntityBuilder {
     }
 
     private MessageBuilder setAddressList(String fieldName, String address) throws ParseException {
-        return setAddressList(fieldName, address == null ? null : AddressBuilder.DEFAULT.parseMailbox(address));
+        return setAddressList(fieldName, address == null ? null : DefaultAddressBuilder.DEFAULT.parseMailbox(address));
     }
 
     private MessageBuilder setAddressList(String fieldName, Address... addresses) {
@@ -847,7 +847,7 @@ public class MessageBuilder extends AbstractEntityBuilder {
         } else {
             List<Address> list = new ArrayList<Address>();
             for (String address: addresses) {
-                list.add(AddressBuilder.DEFAULT.parseAddress(address));
+                list.add(DefaultAddressBuilder.DEFAULT.parseAddress(address));
             }
             return list;
         }

--- a/dom/src/test/java/org/apache/james/mime4j/field/FieldsTest.java
+++ b/dom/src/test/java/org/apache/james/mime4j/field/FieldsTest.java
@@ -35,7 +35,7 @@ import org.apache.james.mime4j.dom.field.ContentTypeField;
 import org.apache.james.mime4j.dom.field.DateTimeField;
 import org.apache.james.mime4j.dom.field.MailboxField;
 import org.apache.james.mime4j.dom.field.MailboxListField;
-import org.apache.james.mime4j.field.address.AddressBuilder;
+import org.apache.james.mime4j.field.address.DefaultAddressBuilder;
 import org.apache.james.mime4j.stream.Field;
 import org.apache.james.mime4j.util.ByteSequence;
 import org.apache.james.mime4j.util.ContentUtil;
@@ -258,15 +258,15 @@ public class FieldsTest {
 
     @Test
     public void testSender() throws Exception {
-        MailboxField field = Fields.sender(AddressBuilder.DEFAULT
+        MailboxField field = Fields.sender(DefaultAddressBuilder.DEFAULT
                 .parseMailbox("JD <john.doe@acme.org>"));
         Assert.assertEquals("Sender: JD <john.doe@acme.org>", decode(field));
     }
 
     @Test
     public void testFrom() throws Exception {
-        Mailbox mailbox1 = AddressBuilder.DEFAULT.parseMailbox("JD <john.doe@acme.org>");
-        Mailbox mailbox2 = AddressBuilder.DEFAULT.parseMailbox("Mary Smith <mary@example.net>");
+        Mailbox mailbox1 = DefaultAddressBuilder.DEFAULT.parseMailbox("JD <john.doe@acme.org>");
+        Mailbox mailbox2 = DefaultAddressBuilder.DEFAULT.parseMailbox("Mary Smith <mary@example.net>");
 
         MailboxListField field = Fields.from(mailbox1);
         Assert.assertEquals("From: JD <john.doe@acme.org>", decode(field));
@@ -282,9 +282,9 @@ public class FieldsTest {
 
     @Test
     public void testTo() throws Exception {
-        Mailbox mailbox1 = AddressBuilder.DEFAULT.parseMailbox("JD <john.doe@acme.org>");
-        Mailbox mailbox2 = AddressBuilder.DEFAULT.parseMailbox("jane.doe@example.org");
-        Mailbox mailbox3 = AddressBuilder.DEFAULT.parseMailbox("Mary Smith <mary@example.net>");
+        Mailbox mailbox1 = DefaultAddressBuilder.DEFAULT.parseMailbox("JD <john.doe@acme.org>");
+        Mailbox mailbox2 = DefaultAddressBuilder.DEFAULT.parseMailbox("jane.doe@example.org");
+        Mailbox mailbox3 = DefaultAddressBuilder.DEFAULT.parseMailbox("Mary Smith <mary@example.net>");
         Group group = new Group("The Does", mailbox1, mailbox2);
 
         AddressListField field = Fields.to(group);
@@ -304,9 +304,9 @@ public class FieldsTest {
 
     @Test
     public void testCc() throws Exception {
-        Mailbox mailbox1 = AddressBuilder.DEFAULT.parseMailbox("JD <john.doe@acme.org>");
-        Mailbox mailbox2 = AddressBuilder.DEFAULT.parseMailbox("jane.doe@example.org");
-        Mailbox mailbox3 = AddressBuilder.DEFAULT.parseMailbox("Mary Smith <mary@example.net>");
+        Mailbox mailbox1 = DefaultAddressBuilder.DEFAULT.parseMailbox("JD <john.doe@acme.org>");
+        Mailbox mailbox2 = DefaultAddressBuilder.DEFAULT.parseMailbox("jane.doe@example.org");
+        Mailbox mailbox3 = DefaultAddressBuilder.DEFAULT.parseMailbox("Mary Smith <mary@example.net>");
         Group group = new Group("The Does", mailbox1, mailbox2);
 
         AddressListField field = Fields.cc(group);
@@ -326,9 +326,9 @@ public class FieldsTest {
 
     @Test
     public void testBcc() throws Exception {
-        Mailbox mailbox1 = AddressBuilder.DEFAULT.parseMailbox("JD <john.doe@acme.org>");
-        Mailbox mailbox2 = AddressBuilder.DEFAULT.parseMailbox("jane.doe@example.org");
-        Mailbox mailbox3 = AddressBuilder.DEFAULT.parseMailbox("Mary Smith <mary@example.net>");
+        Mailbox mailbox1 = DefaultAddressBuilder.DEFAULT.parseMailbox("JD <john.doe@acme.org>");
+        Mailbox mailbox2 = DefaultAddressBuilder.DEFAULT.parseMailbox("jane.doe@example.org");
+        Mailbox mailbox3 = DefaultAddressBuilder.DEFAULT.parseMailbox("Mary Smith <mary@example.net>");
         Group group = new Group("The Does", mailbox1, mailbox2);
 
         AddressListField field = Fields.bcc(group);
@@ -348,9 +348,9 @@ public class FieldsTest {
 
     @Test
     public void testReplyTo() throws Exception {
-        Mailbox mailbox1 = AddressBuilder.DEFAULT.parseMailbox("JD <john.doe@acme.org>");
-        Mailbox mailbox2 = AddressBuilder.DEFAULT.parseMailbox("jane.doe@example.org");
-        Mailbox mailbox3 = AddressBuilder.DEFAULT.parseMailbox("Mary Smith <mary@example.net>");
+        Mailbox mailbox1 = DefaultAddressBuilder.DEFAULT.parseMailbox("JD <john.doe@acme.org>");
+        Mailbox mailbox2 = DefaultAddressBuilder.DEFAULT.parseMailbox("jane.doe@example.org");
+        Mailbox mailbox3 = DefaultAddressBuilder.DEFAULT.parseMailbox("Mary Smith <mary@example.net>");
         Group group = new Group("The Does", mailbox1, mailbox2);
 
         AddressListField field = Fields.replyTo(group);
@@ -370,15 +370,15 @@ public class FieldsTest {
 
     @Test
     public void testMailbox() throws Exception {
-        MailboxField field = Fields.mailbox("Resent-Sender", AddressBuilder.DEFAULT
+        MailboxField field = Fields.mailbox("Resent-Sender", DefaultAddressBuilder.DEFAULT
                 .parseMailbox("JD <john.doe@acme.org>"));
         Assert.assertEquals("Resent-Sender: JD <john.doe@acme.org>", decode(field));
     }
 
     @Test
     public void testMailboxList() throws Exception {
-        Mailbox mailbox1 = AddressBuilder.DEFAULT.parseMailbox("JD <john.doe@acme.org>");
-        Mailbox mailbox2 = AddressBuilder.DEFAULT.parseMailbox("Mary Smith <mary@example.net>");
+        Mailbox mailbox1 = DefaultAddressBuilder.DEFAULT.parseMailbox("JD <john.doe@acme.org>");
+        Mailbox mailbox2 = DefaultAddressBuilder.DEFAULT.parseMailbox("Mary Smith <mary@example.net>");
 
         MailboxListField field = Fields.mailboxList("Resent-From", Arrays
                 .asList(mailbox1, mailbox2));
@@ -388,9 +388,9 @@ public class FieldsTest {
 
     @Test
     public void testAddressList() throws Exception {
-        Mailbox mailbox1 = AddressBuilder.DEFAULT.parseMailbox("JD <john.doe@acme.org>");
-        Mailbox mailbox2 = AddressBuilder.DEFAULT.parseMailbox("jane.doe@example.org");
-        Mailbox mailbox3 = AddressBuilder.DEFAULT.parseMailbox("Mary Smith <mary@example.net>");
+        Mailbox mailbox1 = DefaultAddressBuilder.DEFAULT.parseMailbox("JD <john.doe@acme.org>");
+        Mailbox mailbox2 = DefaultAddressBuilder.DEFAULT.parseMailbox("jane.doe@example.org");
+        Mailbox mailbox3 = DefaultAddressBuilder.DEFAULT.parseMailbox("Mary Smith <mary@example.net>");
         Group group = new Group("The Does", mailbox1, mailbox2);
 
         AddressListField field = Fields.addressList("Resent-To", Arrays.asList(

--- a/dom/src/test/java/org/apache/james/mime4j/field/address/DefaultAddressBuilderTest.java
+++ b/dom/src/test/java/org/apache/james/mime4j/field/address/DefaultAddressBuilderTest.java
@@ -34,11 +34,11 @@ import java.util.List;
 
 public class DefaultAddressBuilderTest {
 
-    private AddressBuilder parser;
+    private DefaultAddressBuilder parser;
 
     @Before
     public void setUp() throws Exception {
-        parser = AddressBuilder.DEFAULT;
+        parser = DefaultAddressBuilder.DEFAULT;
     }
 
     @Test

--- a/dom/src/test/java/org/apache/james/mime4j/message/MessageBuilderTest.java
+++ b/dom/src/test/java/org/apache/james/mime4j/message/MessageBuilderTest.java
@@ -38,7 +38,7 @@ import org.apache.james.mime4j.dom.field.ContentTypeField;
 import org.apache.james.mime4j.dom.field.FieldName;
 import org.apache.james.mime4j.field.DefaultFieldParser;
 import org.apache.james.mime4j.field.Fields;
-import org.apache.james.mime4j.field.address.AddressBuilder;
+import org.apache.james.mime4j.field.address.DefaultAddressBuilder;
 import org.apache.james.mime4j.stream.Field;
 import org.junit.Assert;
 import org.junit.Test;
@@ -194,8 +194,8 @@ public class MessageBuilderTest {
     public void testSetFrom() throws Exception {
         MessageBuilder builder = MessageBuilder.create();
 
-        Mailbox mailbox1 = AddressBuilder.DEFAULT.parseMailbox("john.doe@example.net");
-        Mailbox mailbox2 = AddressBuilder.DEFAULT.parseMailbox("jane.doe@example.net");
+        Mailbox mailbox1 = DefaultAddressBuilder.DEFAULT.parseMailbox("john.doe@example.net");
+        Mailbox mailbox2 = DefaultAddressBuilder.DEFAULT.parseMailbox("jane.doe@example.net");
 
         builder.setFrom(mailbox1);
         Assert.assertEquals("john.doe@example.net", builder.getField("From")
@@ -228,10 +228,10 @@ public class MessageBuilderTest {
     public void testSetTo() throws Exception {
         MessageBuilder builder = MessageBuilder.create();
 
-        Mailbox mailbox1 = AddressBuilder.DEFAULT.parseMailbox("john.doe@example.net");
-        Mailbox mailbox2 = AddressBuilder.DEFAULT.parseMailbox("jane.doe@example.net");
+        Mailbox mailbox1 = DefaultAddressBuilder.DEFAULT.parseMailbox("john.doe@example.net");
+        Mailbox mailbox2 = DefaultAddressBuilder.DEFAULT.parseMailbox("jane.doe@example.net");
         Group group = new Group("Does", mailbox1, mailbox2);
-        Mailbox mailbox3 = AddressBuilder.DEFAULT.parseMailbox("Mary Smith <mary@example.net>");
+        Mailbox mailbox3 = DefaultAddressBuilder.DEFAULT.parseMailbox("Mary Smith <mary@example.net>");
 
         builder.setTo(group);
         Assert.assertEquals("Does: john.doe@example.net, jane.doe@example.net;",
@@ -266,10 +266,10 @@ public class MessageBuilderTest {
     public void testSetCc() throws Exception {
         MessageBuilder builder = MessageBuilder.create();
 
-        Mailbox mailbox1 = AddressBuilder.DEFAULT.parseMailbox("john.doe@example.net");
-        Mailbox mailbox2 = AddressBuilder.DEFAULT.parseMailbox("jane.doe@example.net");
+        Mailbox mailbox1 = DefaultAddressBuilder.DEFAULT.parseMailbox("john.doe@example.net");
+        Mailbox mailbox2 = DefaultAddressBuilder.DEFAULT.parseMailbox("jane.doe@example.net");
         Group group = new Group("Does", mailbox1, mailbox2);
-        Mailbox mailbox3 = AddressBuilder.DEFAULT.parseMailbox("Mary Smith <mary@example.net>");
+        Mailbox mailbox3 = DefaultAddressBuilder.DEFAULT.parseMailbox("Mary Smith <mary@example.net>");
 
         builder.setCc(group);
         Assert.assertEquals("Does: john.doe@example.net, jane.doe@example.net;",
@@ -304,10 +304,10 @@ public class MessageBuilderTest {
     public void testSetBcc() throws Exception {
         MessageBuilder builder = MessageBuilder.create();
 
-        Mailbox mailbox1 = AddressBuilder.DEFAULT.parseMailbox("john.doe@example.net");
-        Mailbox mailbox2 = AddressBuilder.DEFAULT.parseMailbox("jane.doe@example.net");
+        Mailbox mailbox1 = DefaultAddressBuilder.DEFAULT.parseMailbox("john.doe@example.net");
+        Mailbox mailbox2 = DefaultAddressBuilder.DEFAULT.parseMailbox("jane.doe@example.net");
         Group group = new Group("Does", mailbox1, mailbox2);
-        Mailbox mailbox3 = AddressBuilder.DEFAULT.parseMailbox("Mary Smith <mary@example.net>");
+        Mailbox mailbox3 = DefaultAddressBuilder.DEFAULT.parseMailbox("Mary Smith <mary@example.net>");
 
         builder.setBcc(group);
         Assert.assertEquals("Does: john.doe@example.net, jane.doe@example.net;",
@@ -342,10 +342,10 @@ public class MessageBuilderTest {
     public void testSetReplyTo() throws Exception {
         MessageBuilder builder = MessageBuilder.create();
 
-        Mailbox mailbox1 = AddressBuilder.DEFAULT.parseMailbox("john.doe@example.net");
-        Mailbox mailbox2 = AddressBuilder.DEFAULT.parseMailbox("jane.doe@example.net");
+        Mailbox mailbox1 = DefaultAddressBuilder.DEFAULT.parseMailbox("john.doe@example.net");
+        Mailbox mailbox2 = DefaultAddressBuilder.DEFAULT.parseMailbox("jane.doe@example.net");
         Group group = new Group("Does", mailbox1, mailbox2);
-        Mailbox mailbox3 = AddressBuilder.DEFAULT.parseMailbox("Mary Smith <mary@example.net>");
+        Mailbox mailbox3 = DefaultAddressBuilder.DEFAULT.parseMailbox("Mary Smith <mary@example.net>");
 
         builder.setReplyTo(group);
         Assert.assertEquals("Does: john.doe@example.net, jane.doe@example.net;",


### PR DESCRIPTION
New interface SharedAddressBuilder which holds the common methods for AddressBuilder/LenientAddressBuilder. The latter implement this interface.
This should not break anything but allow polymorphic access to those methods.
