### PR TITLE
Add method to allow setting of "no recurse" mode to underlying mime token stream

### DIFF
--- a/core/src/main/java/org/apache/james/mime4j/parser/MimeStreamParser.java
+++ b/core/src/main/java/org/apache/james/mime4j/parser/MimeStreamParser.java
@@ -216,6 +216,14 @@ public class MimeStreamParser {
     }
 
     /**
+     * Disables recursive mode. In this mode rfc822 parts are not
+     * recursively parsed.
+     */
+    public void setNoRecurse() {
+        mimeTokenStream.setRecursionMode(RecursionMode.M_NO_RECURSE);
+    }
+
+    /**
      * Finishes the parsing and stops reading lines.
      * NOTE: No more lines will be parsed but the parser
      * will still call


### PR DESCRIPTION
All other options can be set, except that one. And of course this is the one I'm interested in.
I guess this can't make it into an earlier version than 0.8?

https://issues.apache.org/jira/browse/MIME4J-255