### PR TITLE
Mime4J 252 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,16 @@
                 <version>2.3.7</version>
                 <extensions>true</extensions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.0</version>
+                <configuration>
+                    <optimize>true</optimize>
+                    <source>${target.jdk}</source>
+                    <target>${target.jdk}</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <relativePath/>
     </parent>
 
+    <groupId>org.apache.james</groupId>
     <artifactId>apache-mime4j-project</artifactId>
     <version>0.8.0-SNAPSHOT</version>
     <packaging>pom</packaging>


### PR DESCRIPTION
 - Use java version 1.6 and not 1.4
 - Group Id was removed, as no more inherited by parent, thus blocking release process