### PR TITLE
MIME4J-263, decoding encoded words with empty encoded-text

### DIFF
--- a/core/src/main/java/org/apache/james/mime4j/codec/DecoderUtil.java
+++ b/core/src/main/java/org/apache/james/mime4j/codec/DecoderUtil.java
@@ -35,7 +35,7 @@ import org.apache.james.mime4j.util.CharsetUtil;
 public class DecoderUtil {
 
     private static final Pattern PATTERN_ENCODED_WORD = Pattern.compile(
-            "(.*?)=\\?(.+?)\\?(\\w)\\?(.+?)\\?=", Pattern.DOTALL);
+            "(.*?)=\\?(.+?)\\?(\\w)\\?(.*?)\\?=", Pattern.DOTALL);
 
     /**
      * Decodes a string containing quoted-printable encoded data.
@@ -182,6 +182,9 @@ public class DecoderUtil {
             String mimeCharset = matcher.group(2);
             String encoding = matcher.group(3);
             String encodedText = matcher.group(4);
+
+            if ("".equals(encodedText))
+                return "";
 
             String decoded;
             decoded = tryDecodeEncodedWord(mimeCharset, encoding, encodedText, monitor, fallback);

--- a/core/src/test/java/org/apache/james/mime4j/codec/DecoderUtilTest.java
+++ b/core/src/test/java/org/apache/james/mime4j/codec/DecoderUtilTest.java
@@ -99,8 +99,10 @@ public class DecoderUtilTest {
     @Test
     public void testEmptyEncodedTextIsIgnored() {
         // encoded-text requires at least one character according to rfc 2047
-        Assert.assertEquals("=?ISO-8859-1?Q??=", DecoderUtil.decodeEncodedWords("=?ISO-8859-1?Q??="));
-        Assert.assertEquals("=?ISO-8859-1?B??=", DecoderUtil.decodeEncodedWords("=?ISO-8859-1?B??="));
+        // meanwhile in real life there's emails in real world that contain 0
+        // characters in encoded-text part. Probably makes sense to decode them anyway
+        Assert.assertEquals("", DecoderUtil.decodeEncodedWords("=?ISO-8859-1?Q??="));
+        Assert.assertEquals("", DecoderUtil.decodeEncodedWords("=?ISO-8859-1?B??="));
     }
 
     // see MIME4J-104


### PR DESCRIPTION
Even though the rfc2047 specifies that the encoded-text in encoded word needs at least one character.

I've seen this sort of encoded words around in emails, which the DecoderUtil.decodeEncodedWords() ignores and retuns as-is.

This pull requests changes that behaviour to return an empty string in such cases