### PR TITLE
MIME4J, Update EncoderUtil#encodeB encoding string splitting point.

### DIFF
--- a/core/src/main/java/org/apache/james/mime4j/codec/EncoderUtil.java
+++ b/core/src/main/java/org/apache/james/mime4j/codec/EncoderUtil.java
@@ -539,12 +539,13 @@ public class EncoderUtil {
         if (totalLength <= ENCODED_WORD_MAX_LENGTH - usedCharacters) {
             return prefix + encodeB(bytes) + ENC_WORD_SUFFIX;
         } else {
-            String part1 = text.substring(0, text.length() / 2);
+            int splitOffset = text.offsetByCodePoints(text.length() / 2, -1);
+            String part1 = text.substring(0, splitOffset);
             byte[] bytes1 = encode(part1, charset);
             String word1 = encodeB(prefix, part1, usedCharacters, charset,
                     bytes1);
 
-            String part2 = text.substring(text.length() / 2);
+            String part2 = text.substring(splitOffset);
             byte[] bytes2 = encode(part2, charset);
             String word2 = encodeB(prefix, part2, 0, charset, bytes2);
 

--- a/core/src/test/java/org/apache/james/mime4j/codec/EncoderUtilTest.java
+++ b/core/src/test/java/org/apache/james/mime4j/codec/EncoderUtilTest.java
@@ -140,6 +140,20 @@ public class EncoderUtilTest {
                 Usage.TEXT_TOKEN, 0, null, Encoding.Q);
         Assert.assertTrue(encodedSixtyOne.contains("?= =?US-ASCII?Q?"));
     }
+    
+    @Test
+    public void testEncodeEncodedWordSplitForUnicode() throws Exception {
+        StringBuilder sb = new StringBuilder("z");
+        for (int i = 0; i < 10; i++) {
+            // Append unicode character 𝕫 10 times.
+            sb.append("\uD835\uDD6b");
+        }
+
+        String expected = "=?UTF-8?B?evCdlavwnZWr8J2Vq/Cdlas=?= " +
+                "=?UTF-8?B?8J2Vq/CdlavwnZWr8J2Vq/CdlavwnZWr?=";
+        Assert.assertEquals(expected, EncoderUtil.encodeEncodedWord(sb.toString(),
+                Usage.TEXT_TOKEN, 0, null, Encoding.B));
+    }
 
     @Test
     public void testEncodeEncodedWord() throws Exception {

--- a/core/src/test/java/org/apache/james/mime4j/codec/EncoderUtilTest.java
+++ b/core/src/test/java/org/apache/james/mime4j/codec/EncoderUtilTest.java
@@ -152,7 +152,7 @@ public class EncoderUtilTest {
         String expected = "=?UTF-8?B?evCdlavwnZWr8J2Vq/Cdlas=?= " +
                 "=?UTF-8?B?8J2Vq/CdlavwnZWr8J2Vq/CdlavwnZWr?=";
         Assert.assertEquals(expected, EncoderUtil.encodeEncodedWord(sb.toString(),
-                Usage.TEXT_TOKEN, 0, null, Encoding.B));
+                Usage.TEXT_TOKEN, 10, null, Encoding.B));
     }
 
     @Test


### PR DESCRIPTION
Without the change made in EncoderUtil, the newly added test would fail.