### PR TITLE
MIME4J-289 Upgrade libs

### DIFF
--- a/assemble/pom.xml
+++ b/assemble/pom.xml
@@ -56,6 +56,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.1.1</version>
                 <configuration>
                     <descriptorSourceDirectory>${basedir}/src/assemble/</descriptorSourceDirectory>
                     <tarLongFileMode>gnu</tarLongFileMode>
@@ -65,7 +66,7 @@
                         <id>make-assembly</id>
                         <phase>package</phase>
                         <goals>
-                            <goal>attached</goal>
+                            <goal>single</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/james-utils/pom.xml
+++ b/james-utils/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <version>28.1-jre</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/james-utils/pom.xml
+++ b/james-utils/pom.xml
@@ -58,7 +58,6 @@
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
-            <version>1.7.1</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/james-utils/pom.xml
+++ b/james-utils/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.7</version>
+            <version>1.7.28</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>18</version>
+        <version>21</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
 
         <target.jdk>1.8</target.jdk>
         <commons-logging.version>1.2</commons-logging.version>
-        <log4j.version>1.2.14</log4j.version>
+        <log4j.version>1.2.17</log4j.version>
         <junit.version>4.12</junit.version>
         <mockito.version>1.9.5</mockito.version>
         <commons-io.version>2.6</commons-io.version>

--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.3.7</version>
+                <version>4.2.1</version>
                 <extensions>true</extensions>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <commons-logging.version>1.2</commons-logging.version>
         <log4j.version>1.2.17</log4j.version>
         <junit.version>4.12</junit.version>
-        <mockito.version>1.9.5</mockito.version>
+        <mockito.version>3.0.0</mockito.version>
         <commons-io.version>2.6</commons-io.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
-                <version>1.7.1</version>
+                <version>3.13.2</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <target.jdk>1.8</target.jdk>
         <commons-logging.version>1.2</commons-logging.version>
         <log4j.version>1.2.14</log4j.version>
-        <junit.version>4.10</junit.version>
+        <junit.version>4.12</junit.version>
         <mockito.version>1.9.5</mockito.version>
         <commons-io.version>2.6</commons-io.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.0</version>
+                <version>3.8.1</version>
                 <configuration>
                     <optimize>true</optimize>
                     <source>${target.jdk}</source>

--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.1.2</version>
                 <executions>
                     <execution>
                         <id>jar</id>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <james-skin.version>1.8</james-skin.version>
 
         <target.jdk>1.8</target.jdk>
-        <commons-logging.version>1.1.1</commons-logging.version>
+        <commons-logging.version>1.2</commons-logging.version>
         <log4j.version>1.2.14</log4j.version>
         <junit.version>4.10</junit.version>
         <mockito.version>1.9.5</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <log4j.version>1.2.14</log4j.version>
         <junit.version>4.10</junit.version>
         <mockito.version>1.9.5</mockito.version>
-        <commons-io.version>2.4</commons-io.version>
+        <commons-io.version>2.6</commons-io.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
```
      1 [INFO]   com.google.guava:guava .............................. 18.0 -> 28.1-jre
      9 [INFO]   commons-io:commons-io ..................................... 2.4 -> 2.6
      9 [INFO]   commons-logging:commons-logging ......................... 1.1.1 -> 1.2
      9 [INFO]   junit:junit ...................................... 4.10 -> 4.12
      9 [INFO]   log4j:log4j ......................................... 1.2.14 -> 1.2.17
     18 [INFO]   org.apache.maven.doxia:doxia-core ......................... 1.2 -> 1.9
      9 [INFO]   org.assertj:assertj-core ............................. 1.7.1 -> 3.13.2
      9 [INFO]   org.mockito:mockito-core .............................. 1.9.5 -> 3.0.0
      1 [INFO]   org.slf4j:slf4j-api ............................ 1.7.7 -> 1.7.18
```