### PR TITLE
MIME4J-295 Allow for overriding the specified charset when decoding q or b encoded words

### DIFF
--- a/core/src/main/java/org/apache/james/mime4j/codec/DecoderUtil.java
+++ b/core/src/main/java/org/apache/james/mime4j/codec/DecoderUtil.java
@@ -280,15 +280,11 @@ public class DecoderUtil {
             final Charset fallback,
             final Map<Charset, Charset> charsetOverrides) {
         Charset charset = CharsetUtil.lookup(mimeCharset);
-        if (charset != null) {
-            Charset override = charsetOverrides.get(charset);
-            if (override != null) {
-                charset = override;
-            }
-        } else {
-            charset = fallback;
+        if (charset == null) {
+            return fallback;
         }
-        return charset;
+        Charset override = charsetOverrides.get(charset);
+        return override != null ? override : charset;
     }
 
     private static void monitor(DecodeMonitor monitor, String mimeCharset, String encoding,

--- a/core/src/test/java/org/apache/james/mime4j/codec/DecoderUtilTest.java
+++ b/core/src/test/java/org/apache/james/mime4j/codec/DecoderUtilTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.util.HashMap;
 
 public class DecoderUtilTest {
 
@@ -156,5 +157,13 @@ public class DecoderUtilTest {
     public void testFunnyInputDoesNotRaiseOutOfMemoryError() {
         // Bug detected on June 7, 2005. Decoding the following string caused OutOfMemoryError.
         Assert.assertEquals("=3?!!\\=?\"!g6P\"!Xp:\"!", DecoderUtil.decodeEncodedWords("=3?!!\\=?\"!g6P\"!Xp:\"!"));
+    }
+
+    @Test
+    public void testAllowsForOverriddingCharsets() {
+        HashMap<Charset, Charset> overrides = new HashMap<Charset, Charset>();
+        overrides.put(Charset.forName("ISO-8859-1"), Charset.forName("WINDOWS-1252"));
+        String decoded = DecoderUtil.decodeEncodedWords("=?ISO-8859-1?Q?You=92re_a_winner?=", DecodeMonitor.SILENT, null, overrides);
+        Assert.assertEquals("You’re a winner", decoded);
     }
 }


### PR DESCRIPTION
It it very common to recieve mislabeled charsets for windows-1252, which usually end up
being ISO-8898-1. This is a minimal change allows our email servers to not have to rewrite
q-encoding, but doesn't change any default behaviors within Mime4J.

/cc @ryanpbrewster