### PR TITLE
MIME4J-290 Fix build for recent mvn and JDK versions

### DIFF
--- a/dom/src/test/java/org/apache/james/mime4j/dom/MessageCharsetLenientTest.java
+++ b/dom/src/test/java/org/apache/james/mime4j/dom/MessageCharsetLenientTest.java
@@ -20,6 +20,7 @@ package org.apache.james.mime4j.dom;
 
 import java.io.ByteArrayInputStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 
 import org.apache.james.mime4j.message.BasicBodyFactory;
 import org.apache.james.mime4j.message.DefaultMessageBuilder;
@@ -78,7 +79,6 @@ public class MessageCharsetLenientTest {
 				"iso-8589-0",
 				"iso-8814-4",
 				"iso-8859-1 name=FAQ.htm",
-				"iso-8859-16",
 				"iso-8859-1?",
 				"iso-8859-8-i",
 				"iso-9284-4",

--- a/dom/src/test/java/org/apache/james/mime4j/dom/MessageCharsetLenientTest.java
+++ b/dom/src/test/java/org/apache/james/mime4j/dom/MessageCharsetLenientTest.java
@@ -20,7 +20,6 @@ package org.apache.james.mime4j.dom;
 
 import java.io.ByteArrayInputStream;
 import java.io.UnsupportedEncodingException;
-import java.nio.charset.Charset;
 
 import org.apache.james.mime4j.message.BasicBodyFactory;
 import org.apache.james.mime4j.message.DefaultMessageBuilder;

--- a/james-utils/src/test/java/org/apache/james/mime4j/utils/search/MessageMatcherTest.java
+++ b/james-utils/src/test/java/org/apache/james/mime4j/utils/search/MessageMatcherTest.java
@@ -19,7 +19,7 @@
 package org.apache.james.mime4j.utils.search;
 
 import com.google.common.collect.Lists;
-import com.sun.org.apache.bcel.internal.util.ClassLoader;
+import java.io.InputStream;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,7 +33,7 @@ public class MessageMatcherTest {
             .caseInsensitive(true)
             .includeHeaders(false)
             .build();
-        assertThat(messageMatcher.messageMatches(ClassLoader.getSystemResourceAsStream("sampleMail.msg"))).isTrue();
+        assertThat(messageMatcher.messageMatches(getResourceStream("sampleMail.msg"))).isTrue();
     }
 
     @Test
@@ -43,7 +43,7 @@ public class MessageMatcherTest {
             .caseInsensitive(true)
             .includeHeaders(false)
             .build();
-        assertThat(messageMatcher.messageMatches(ClassLoader.getSystemResourceAsStream("sampleMail.msg"))).isFalse();
+        assertThat(messageMatcher.messageMatches(getResourceStream("sampleMail.msg"))).isFalse();
     }
 
     @Test
@@ -53,7 +53,7 @@ public class MessageMatcherTest {
             .caseInsensitive(true)
             .includeHeaders(false)
             .build();
-        assertThat(messageMatcher.messageMatches(ClassLoader.getSystemResourceAsStream("sampleMail.msg"))).isFalse();
+        assertThat(messageMatcher.messageMatches(getResourceStream("sampleMail.msg"))).isFalse();
     }
 
     @Test
@@ -64,7 +64,7 @@ public class MessageMatcherTest {
             .includeHeaders(false)
             .contentTypes(Lists.newArrayList("invalid"))
             .build();
-        assertThat(messageMatcher.messageMatches(ClassLoader.getSystemResourceAsStream("sampleMail.msg"))).isFalse();
+        assertThat(messageMatcher.messageMatches(getResourceStream("sampleMail.msg"))).isFalse();
     }
 
     @Test
@@ -75,7 +75,7 @@ public class MessageMatcherTest {
             .includeHeaders(false)
             .contentTypes(Lists.newArrayList("text/plain"))
             .build();
-        assertThat(messageMatcher.messageMatches(ClassLoader.getSystemResourceAsStream("sampleMail.msg"))).isTrue();
+        assertThat(messageMatcher.messageMatches(getResourceStream("sampleMail.msg"))).isTrue();
     }
 
     @Test
@@ -86,7 +86,7 @@ public class MessageMatcherTest {
             .includeHeaders(false)
             .contentTypes(Lists.newArrayList("text/plain"))
             .build();
-        assertThat(messageMatcher.messageMatches(ClassLoader.getSystemResourceAsStream("sampleMail.msg"))).isTrue();
+        assertThat(messageMatcher.messageMatches(getResourceStream("sampleMail.msg"))).isTrue();
     }
 
     @Test
@@ -97,7 +97,7 @@ public class MessageMatcherTest {
             .includeHeaders(false)
             .contentTypes(Lists.newArrayList("text/plain", "invalid"))
             .build();
-        assertThat(messageMatcher.messageMatches(ClassLoader.getSystemResourceAsStream("sampleMail.msg"))).isTrue();
+        assertThat(messageMatcher.messageMatches(getResourceStream("sampleMail.msg"))).isTrue();
     }
 
     @Test
@@ -108,7 +108,7 @@ public class MessageMatcherTest {
             .includeHeaders(false)
             .contentTypes(Lists.newArrayList("text/plain", "invalid"))
             .build();
-        assertThat(messageMatcher.messageMatches(ClassLoader.getSystemResourceAsStream("sampleMail.msg"))).isTrue();
+        assertThat(messageMatcher.messageMatches(getResourceStream("sampleMail.msg"))).isTrue();
     }
 
     @Test
@@ -119,7 +119,7 @@ public class MessageMatcherTest {
             .includeHeaders(false)
             .contentTypes(Lists.newArrayList("text/plain", "invalid"))
             .build();
-        assertThat(messageMatcher.messageMatches(ClassLoader.getSystemResourceAsStream("sampleMail.msg"))).isFalse();
+        assertThat(messageMatcher.messageMatches(getResourceStream("sampleMail.msg"))).isFalse();
     }
 
     @Test
@@ -130,7 +130,7 @@ public class MessageMatcherTest {
             .includeHeaders(true)
             .contentTypes(Lists.<String>newArrayList())
             .build();
-        assertThat(messageMatcher.messageMatches(ClassLoader.getSystemResourceAsStream("sampleMail.msg"))).isTrue();
+        assertThat(messageMatcher.messageMatches(getResourceStream("sampleMail.msg"))).isTrue();
     }
 
     @Test
@@ -139,7 +139,7 @@ public class MessageMatcherTest {
             .searchContents(Lists.<CharSequence>newArrayList("message/rfc822"))
             .ignoringMime(true)
             .build();
-        assertThat(messageMatcher.messageMatches(ClassLoader.getSystemResourceAsStream("sampleMail.msg"))).isTrue();
+        assertThat(messageMatcher.messageMatches(getResourceStream("sampleMail.msg"))).isTrue();
     }
 
     @Test
@@ -148,7 +148,7 @@ public class MessageMatcherTest {
             .searchContents(Lists.<CharSequence>newArrayList("ail signature )\n\n--------------0004"))
             .ignoringMime(true)
             .build();
-        assertThat(messageMatcher.messageMatches(ClassLoader.getSystemResourceAsStream("sampleMail.msg"))).isTrue();
+        assertThat(messageMatcher.messageMatches(getResourceStream("sampleMail.msg"))).isTrue();
     }
 
     @Test
@@ -157,7 +157,11 @@ public class MessageMatcherTest {
             .searchContents(Lists.<CharSequence>newArrayList("invalid"))
             .ignoringMime(true)
             .build();
-        assertThat(messageMatcher.messageMatches(ClassLoader.getSystemResourceAsStream("sampleMail.msg"))).isFalse();
+        assertThat(messageMatcher.messageMatches(getResourceStream("sampleMail.msg"))).isFalse();
+    }
+
+    private InputStream getResourceStream(String resourceName) {
+        return ClassLoader.getSystemClassLoader().getResourceAsStream(resourceName);
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>4.2.1</version>
+                <version>5.1.1</version>
                 <extensions>true</extensions>
             </plugin>
             <plugin>


### PR DESCRIPTION
Changes:
* There was a maven plugin that needed to be updated
* `iso-8859-16` is a legal charset that the JDK now supplies
* `com.sun.org.apache.bcel.internal.util.ClassLoader` was not found during compiling, so I switched to the builtin ClassLoader

Result:
The tests pass for me on a macbook with JDK 15 and mvn `3.6.3`