### PR TITLE
JAMES-3226 Ignore Antora doc missing licenses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,7 @@
                         </goals>
                         <configuration>
                             <excludes>
+                                <exclude>**/docs/**</exclude>
                                 <exclude>CHANGELOG.*</exclude>
                                 <exclude>NOTICE.*</exclude>
                                 <exclude>LICENSE.*</exclude>


### PR DESCRIPTION
While running tests for https://github.com/apache/james-mime4j/pull/35 https://github.com/apache/james-mime4j/pull/34 the ANT plugin was failing...