### PR TITLE
MIME4J-299 Access to the Header map

### DIFF
--- a/dom/src/main/java/org/apache/james/mime4j/dom/Header.java
+++ b/dom/src/main/java/org/apache/james/mime4j/dom/Header.java
@@ -21,6 +21,7 @@ package org.apache.james.mime4j.dom;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.james.mime4j.stream.Field;
 
@@ -43,6 +44,14 @@ public interface Header extends Iterable<Field> {
      * @return the list of <code>Field</code> objects.
      */
     List<Field> getFields();
+
+    /**
+     * Gets the fields of this header. The returned map will not be
+     * modifiable.
+     *
+     * @return the map of <code>Field</code> objects indexed by names.
+     */
+    Map<String, List<Field>> getFieldsAsMap();
 
     /**
      * Gets a <code>Field</code> given a field name. If there are multiple

--- a/dom/src/main/java/org/apache/james/mime4j/dom/Header.java
+++ b/dom/src/main/java/org/apache/james/mime4j/dom/Header.java
@@ -47,7 +47,8 @@ public interface Header extends Iterable<Field> {
 
     /**
      * Gets the fields of this header. The returned map will not be
-     * modifiable.
+     * modifiable. For each header name, values are ordered by which
+     * they appear in the underlying entity.
      *
      * @return the map of <code>Field</code> objects indexed by names.
      */

--- a/dom/src/main/java/org/apache/james/mime4j/message/AbstractHeader.java
+++ b/dom/src/main/java/org/apache/james/mime4j/message/AbstractHeader.java
@@ -88,7 +88,8 @@ public abstract class AbstractHeader implements Header {
 
     /**
      * Gets the fields of this header. The returned map will not be
-     * modifiable.
+     * modifiable. For each header name, values are ordered by which
+     * they appear in the underlying entity.
      *
      * @return the map of <code>Field</code> objects indexed by names.
      */

--- a/dom/src/main/java/org/apache/james/mime4j/message/AbstractHeader.java
+++ b/dom/src/main/java/org/apache/james/mime4j/message/AbstractHeader.java
@@ -87,6 +87,17 @@ public abstract class AbstractHeader implements Header {
     }
 
     /**
+     * Gets the fields of this header. The returned map will not be
+     * modifiable.
+     *
+     * @return the map of <code>Field</code> objects indexed by names.
+     */
+    @Override
+    public Map<String, List<Field>> getFieldsAsMap() {
+        return Collections.unmodifiableMap(fieldMap);
+    }
+
+    /**
      * Gets a <code>Field</code> given a field name. If there are multiple
      * such fields defined in this header the first one will be returned.
      *


### PR DESCRIPTION
Preserving the "grouped by name" structure can ease the work of callers.