### PR TITLE
MIME4J-301 ContentTypeFieldImpl do fill a stacktrace when ended by a …

### DIFF
--- a/dom/src/main/javacc/org/apache/james/mime4j/field/contenttype/ContentTypeParser.jj
+++ b/dom/src/main/javacc/org/apache/james/mime4j/field/contenttype/ContentTypeParser.jj
@@ -108,7 +108,7 @@ void parse() :
 		this.type = type.image;
 		this.subtype = subtype.image;
 	}
-	( ";" parameter() )*
+	( ";" (parameter())? )*
 }
 
 void parameter() :

--- a/dom/src/test/java/org/apache/james/mime4j/field/ContentTypeFieldTest.java
+++ b/dom/src/test/java/org/apache/james/mime4j/field/ContentTypeFieldTest.java
@@ -44,6 +44,14 @@ public class ContentTypeFieldTest {
     }
 
     @Test
+    public void extraSemicolonShouldNotAbortParameterParsing() throws Exception {
+        ContentTypeField f = parse("Content-Type: text/html;; charset=utf-8");
+        Assert.assertEquals("text/html", f.getMimeType());
+        Assert.assertEquals("utf-8", f.getCharset());
+        Assert.assertNull(f.getParseException());
+    }
+
+    @Test
     public void testGetMimeType() throws Exception {
         ContentTypeField f = parse("Content-Type: text/PLAIN");
         Assert.assertEquals("text/plain", f.getMimeType());

--- a/dom/src/test/java/org/apache/james/mime4j/field/ContentTypeFieldTest.java
+++ b/dom/src/test/java/org/apache/james/mime4j/field/ContentTypeFieldTest.java
@@ -40,6 +40,7 @@ public class ContentTypeFieldTest {
     public void testMimeTypeWithSemiColonNoParams() throws Exception {
         ContentTypeField f = parse("Content-Type: text/html;");
         Assert.assertEquals("text/html", f.getMimeType());
+        Assert.assertNull(f.getParseException());
     }
 
     @Test


### PR DESCRIPTION
…semicolon

While running some performance tests for the Apache James server, I noted a bunch of time spent filling some stacktraces while parsing some content types.

![Screenshot from 2021-06-15 14-07-06](https://user-images.githubusercontent.com/6928740/122008471-4c853280-cde3-11eb-9eff-05ccf162df66.png)

I noted that inputs like `Content-Type: text/plain;` was causing ContentTypeFieldImpl to fill some stacktraces while not preventing this class from doing a correct parsing.

As such, it make sense to me to consider such inputs as valid.