### PR TITLE
MIME4J-298 Convert DateTimeFieldLenientImpl to DateTimeFormatter

### DIFF
--- a/dom/src/main/java/org/apache/james/mime4j/field/DateTimeFieldLenientImpl.java
+++ b/dom/src/main/java/org/apache/james/mime4j/field/DateTimeFieldLenientImpl.java
@@ -83,6 +83,10 @@ public class DateTimeFieldLenientImpl extends AbstractField implements DateTimeF
             .appendLiteral(' ')
             .appendPattern("0000")
         .optionalEnd()
+        .optionalStart()
+            .appendLiteral(' ')
+            .appendPattern("(zzz)")
+        .optionalEnd()
         .toFormatter()
         .withZone(ZoneId.of("GMT"));
 

--- a/dom/src/main/java/org/apache/james/mime4j/field/DateTimeFieldLenientImpl.java
+++ b/dom/src/main/java/org/apache/james/mime4j/field/DateTimeFieldLenientImpl.java
@@ -19,14 +19,23 @@
 
 package org.apache.james.mime4j.field;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Arrays;
-import java.util.Collections;
+import static java.time.temporal.ChronoField.DAY_OF_MONTH;
+import static java.time.temporal.ChronoField.DAY_OF_WEEK;
+import static java.time.temporal.ChronoField.HOUR_OF_DAY;
+import static java.time.temporal.ChronoField.MILLI_OF_SECOND;
+import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
+import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
+import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
+import static java.time.temporal.ChronoField.YEAR;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.SignStyle;
 import java.util.Date;
-import java.util.List;
-import java.util.Locale;
-import java.util.TimeZone;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.james.mime4j.codec.DecodeMonitor;
 import org.apache.james.mime4j.dom.FieldParser;
@@ -37,34 +46,80 @@ import org.apache.james.mime4j.stream.Field;
  * Date-time field such as <code>Date</code> or <code>Resent-Date</code>.
  */
 public class DateTimeFieldLenientImpl extends AbstractField implements DateTimeField {
+    private static final int INITIAL_YEAR = 1970;
+    public static final DateTimeFormatter RFC_5322 = new DateTimeFormatterBuilder()
+        .parseCaseInsensitive()
+        .parseLenient()
+        .optionalStart()
+            .appendText(DAY_OF_WEEK, dayOfWeek())
+            .appendLiteral(", ")
+        .optionalEnd()
+        .appendValue(DAY_OF_MONTH, 1, 2, SignStyle.NOT_NEGATIVE)
+        .appendLiteral(' ')
+        .appendText(MONTH_OF_YEAR, monthOfYear())
+        .appendLiteral(' ')
+        .appendValueReduced(YEAR, 2, 4, INITIAL_YEAR)
+        .appendLiteral(' ')
+        .appendValue(HOUR_OF_DAY, 2)
+        .appendLiteral(':')
+        .appendValue(MINUTE_OF_HOUR, 2)
+        .optionalStart()
+            .appendLiteral(':')
+            .appendValue(SECOND_OF_MINUTE, 2)
+        .optionalEnd()
+        .optionalStart()
+            .appendLiteral('.')
+            .appendValue(MILLI_OF_SECOND, 3)
+        .optionalEnd()
+        .optionalStart()
+            .appendLiteral(' ')
+            .appendOffset("+HHMM", "GMT")
+        .optionalEnd()
+        .optionalStart()
+            .appendLiteral(' ')
+            .appendOffsetId()
+        .optionalEnd()
+        .optionalStart()
+            .appendLiteral(' ')
+            .appendPattern("0000")
+        .optionalEnd()
+        .toFormatter()
+        .withZone(ZoneId.of("GMT"));
 
-    private static final String[] DEFAULT_DATE_FORMATS = {
-        "EEE, dd MMM yy HH:mm:ss ZZZZ",
-        "dd MMM yy HH:mm:ss ZZZZ",
-        "EEE, dd MMM yy HH:mm:ss.SSS 0000",
-        "EEE, dd MMM yy HH:mm:ss 0000",
-        "EEE, dd MMM yyyy HH:mm:ss ZZZZ",
-        "dd MMM yyyy HH:mm:ss ZZZZ",
-        "EEE, dd MMM yyyy HH:mm:ss.SSS 0000",
-        "EEE, dd MMM yyyy HH:mm:ss 0000",
-        "EEE, dd MMM yy HH:mm:ss X",
-        "dd MMM yy HH:mm:ss X",
-        "EEE, dd MMM yy HH:mm:ss.SSS X",
-        "EEE, dd MMM yy HH:mm:ss X",
-        "EEE, dd MMM yyyy HH:mm:ss X",
-        "dd MMM yyyy HH:mm:ss X",
-        "EEE, dd MMM yyyy HH:mm:ss.SSS X",
-        "EEE, dd MMM yyyy HH:mm:ss X",
-    };
+    private static Map<Long, String> monthOfYear() {
+        HashMap<Long, String> result = new HashMap<>();
+        result.put(1L, "Jan");
+        result.put(2L, "Feb");
+        result.put(3L, "Mar");
+        result.put(4L, "Apr");
+        result.put(5L, "May");
+        result.put(6L, "Jun");
+        result.put(7L, "Jul");
+        result.put(8L, "Aug");
+        result.put(9L, "Sep");
+        result.put(10L, "Oct");
+        result.put(11L, "Nov");
+        result.put(12L, "Dec");
+        return result;
+    }
 
-    private final List<String> datePatterns;
+    private static Map<Long, String> dayOfWeek() {
+        HashMap<Long, String> result = new HashMap<>();
+        result.put(1L, "Mon");
+        result.put(2L, "Tue");
+        result.put(3L, "Wed");
+        result.put(4L, "Thu");
+        result.put(5L, "Fri");
+        result.put(6L, "Sat");
+        result.put(7L, "Sun");
+        return result;
+    }
 
     private boolean parsed = false;
     private Date date;
 
     private DateTimeFieldLenientImpl(Field rawField, DecodeMonitor monitor) {
         super(rawField, monitor);
-        this.datePatterns = Collections.unmodifiableList(Arrays.asList(DEFAULT_DATE_FORMATS));
     }
 
     public Date getDate() {
@@ -81,16 +136,7 @@ public class DateTimeFieldLenientImpl extends AbstractField implements DateTimeF
         if (body != null) {
             body = body.trim();
         }
-        for (String datePattern : datePatterns) {
-            try {
-                SimpleDateFormat parser = new SimpleDateFormat(datePattern, Locale.US);
-                parser.setTimeZone(TimeZone.getTimeZone("GMT"));
-                parser.setLenient(true);
-                date = parser.parse(body);
-                break;
-            } catch (ParseException ignore) {
-            }
-        }
+        date = Date.from(Instant.from(RFC_5322.parse(body)));
     }
 
     public static final FieldParser<DateTimeField> PARSER = new FieldParser<DateTimeField>() {

--- a/dom/src/main/java/org/apache/james/mime4j/field/DateTimeFieldLenientImpl.java
+++ b/dom/src/main/java/org/apache/james/mime4j/field/DateTimeFieldLenientImpl.java
@@ -28,11 +28,13 @@ import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
 import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
 import static java.time.temporal.ChronoField.YEAR;
 
+import java.text.ParsePosition;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.SignStyle;
+import java.time.temporal.TemporalField;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -140,7 +142,11 @@ public class DateTimeFieldLenientImpl extends AbstractField implements DateTimeF
         if (body != null) {
             body = body.trim();
         }
-        date = Date.from(Instant.from(RFC_5322.parse(body)));
+        try {
+            date = Date.from(Instant.from(RFC_5322.parse(body, new ParsePosition(0))));
+        } catch (Exception e) {
+            // Ignore
+        }
     }
 
     public static final FieldParser<DateTimeField> PARSER = new FieldParser<DateTimeField>() {

--- a/dom/src/main/java/org/apache/james/mime4j/field/DateTimeFieldLenientImpl.java
+++ b/dom/src/main/java/org/apache/james/mime4j/field/DateTimeFieldLenientImpl.java
@@ -25,6 +25,7 @@ import static java.time.temporal.ChronoField.HOUR_OF_DAY;
 import static java.time.temporal.ChronoField.MILLI_OF_SECOND;
 import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
 import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
+import static java.time.temporal.ChronoField.OFFSET_SECONDS;
 import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
 import static java.time.temporal.ChronoField.YEAR;
 
@@ -33,10 +34,13 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.ResolverStyle;
 import java.time.format.SignStyle;
+import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalField;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import org.apache.james.mime4j.codec.DecodeMonitor;
@@ -85,12 +89,11 @@ public class DateTimeFieldLenientImpl extends AbstractField implements DateTimeF
             .appendLiteral(' ')
             .appendPattern("0000")
         .optionalEnd()
-        .optionalStart()
-            .appendLiteral(' ')
-            .appendPattern("(zzz)")
-        .optionalEnd()
         .toFormatter()
-        .withZone(ZoneId.of("GMT"));
+        .withZone(ZoneId.of("GMT"))
+        .withResolverStyle(ResolverStyle.LENIENT)
+        .withResolverFields(DAY_OF_MONTH, MONTH_OF_YEAR, YEAR, HOUR_OF_DAY, MINUTE_OF_HOUR, SECOND_OF_MINUTE, MILLI_OF_SECOND, OFFSET_SECONDS)
+        .withLocale(Locale.US);
 
     private static Map<Long, String> monthOfYear() {
         HashMap<Long, String> result = new HashMap<>();

--- a/dom/src/test/java/org/apache/james/mime4j/field/LenientDateTimeFieldTest.java
+++ b/dom/src/test/java/org/apache/james/mime4j/field/LenientDateTimeFieldTest.java
@@ -82,6 +82,13 @@ public class LenientDateTimeFieldTest {
     }
 
     @Test
+    public void parseShouldAcceptWrongDayOfWeek() throws Exception {
+        // Should be Thu
+        DateTimeField f = parse("Date: Fri, 01 Jan 1970 12:00:00 +0000");
+        Assert.assertEquals(43200000L, f.getDate().getTime());
+    }
+
+    @Test
     public void testMime4j219() throws Exception {
         DateTimeField f = parse("Date: Tue, 17 Jul 2012 22:23:35.882 0000");
         Assert.assertEquals(1342563815882L, f.getDate().getTime());

--- a/dom/src/test/java/org/apache/james/mime4j/field/LenientDateTimeFieldTest.java
+++ b/dom/src/test/java/org/apache/james/mime4j/field/LenientDateTimeFieldTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.mime4j.field;
 
+import java.util.Date;
+
 import org.apache.james.mime4j.MimeException;
 import org.apache.james.mime4j.dom.field.DateTimeField;
 import org.apache.james.mime4j.stream.RawField;
@@ -26,10 +28,7 @@ import org.apache.james.mime4j.stream.RawFieldParser;
 import org.apache.james.mime4j.util.ByteSequence;
 import org.apache.james.mime4j.util.ContentUtil;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
-
-import java.util.Date;
 
 public class LenientDateTimeFieldTest {
 
@@ -51,7 +50,6 @@ public class LenientDateTimeFieldTest {
         Assert.assertEquals(new Date(1216221153000L), f.getDate());
     }
 
-    @Ignore("java.time.format.DateTimeParseException: Text 'Thu, 4 Oct 2001 20:12:26 -0700 (PDT),Thu, 4 Oct 2001 20:12:26 -0...' could not be parsed at index 36")
     @Test
     public void extraCharsShouldBeTolerated() throws Exception {
         DateTimeField f = parse("Date: Thu, 4 Oct 2001 20:12:26 -0700 (PDT),Thu, 4 Oct 2001 20:12:26 -0700");

--- a/dom/src/test/java/org/apache/james/mime4j/field/LenientDateTimeFieldTest.java
+++ b/dom/src/test/java/org/apache/james/mime4j/field/LenientDateTimeFieldTest.java
@@ -26,6 +26,7 @@ import org.apache.james.mime4j.stream.RawFieldParser;
 import org.apache.james.mime4j.util.ByteSequence;
 import org.apache.james.mime4j.util.ContentUtil;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Date;
@@ -42,6 +43,19 @@ public class LenientDateTimeFieldTest {
     public void testDateDST() throws Exception {
         DateTimeField f = parse("Date: Wed, 16 Jul 2008 17:12:33 +0200");
         Assert.assertEquals(new Date(1216221153000L), f.getDate());
+    }
+
+    @Test
+    public void extraPDTShouldBeTolerated() throws Exception {
+        DateTimeField f = parse("Date: Wed, 16 Jul 2008 17:12:33 +0200 (PDT)");
+        Assert.assertEquals(new Date(1216221153000L), f.getDate());
+    }
+
+    @Ignore("java.time.format.DateTimeParseException: Text 'Thu, 4 Oct 2001 20:12:26 -0700 (PDT),Thu, 4 Oct 2001 20:12:26 -0...' could not be parsed at index 36")
+    @Test
+    public void extraCharsShouldBeTolerated() throws Exception {
+        DateTimeField f = parse("Date: Thu, 4 Oct 2001 20:12:26 -0700 (PDT),Thu, 4 Oct 2001 20:12:26 -0700");
+        Assert.assertEquals(new Date(1002251546000L), f.getDate());
     }
 
     @Test


### PR DESCRIPTION
This allows:

 - Specifying all patterns at once, avoiding one parsing pass per pattern
 - DateTimeFormatter is thread safe, thus can be initialized once and reused
 
## Why

`AbstractMessage.getDate` represents 6.5% of total memory allocation and 2.5% of CPU allocations in my James JMAP performance tests, doing many parser initialization and parsing passes.

Below is a flame graph detailing operations performed.

![MIME4J-298-cpu](https://user-images.githubusercontent.com/6928740/122166127-5f5f3c00-cea3-11eb-9424-d561109c3d16.png)

![MIME4J-298-mem](https://user-images.githubusercontent.com/6928740/122166144-62f2c300-cea3-11eb-8b00-5ffcc6dee596.png)

 - [x] TODO measure the improvments
 
 This work is inspired from @aduprat work on `ImapDateTimeFormatter` in James code base.