### PR TITLE
MIME4J-302 MessageBuilder::parse repeatedly calls toLowerCase on header names

### DIFF
--- a/core/src/main/java/org/apache/james/mime4j/stream/FallbackBodyDescriptorBuilder.java
+++ b/core/src/main/java/org/apache/james/mime4j/stream/FallbackBodyDescriptorBuilder.java
@@ -117,7 +117,7 @@ class FallbackBodyDescriptorBuilder implements BodyDescriptorBuilder {
      * @param field the MIME field.
      */
     public Field addField(RawField field) throws MimeException {
-        String name = field.getName().toLowerCase(Locale.US);
+        String name = field.getNameLowerCase();
 
         if (name.equals("content-transfer-encoding") && transferEncoding == null) {
             String value = field.getBody();

--- a/core/src/main/java/org/apache/james/mime4j/stream/Field.java
+++ b/core/src/main/java/org/apache/james/mime4j/stream/Field.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.mime4j.stream;
 
+import java.util.Locale;
+
 import org.apache.james.mime4j.util.ByteSequence;
 
 /**
@@ -38,6 +40,13 @@ public interface Field {
      * Returns the name of the field.
      */
     String getName();
+
+    /**
+     * Returns the name of the field in lower case.
+     */
+    default String getNameLowerCase() {
+        return getName().toLowerCase(Locale.US);
+    }
 
     /**
      * Gets the unparsed and possibly encoded (see RFC 2047) field body string.

--- a/core/src/main/java/org/apache/james/mime4j/stream/RawField.java
+++ b/core/src/main/java/org/apache/james/mime4j/stream/RawField.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.mime4j.stream;
 
+import java.util.Locale;
+
 import org.apache.james.mime4j.util.ByteSequence;
 import org.apache.james.mime4j.util.CharsetUtil;
 import org.apache.james.mime4j.util.ContentUtil;
@@ -39,6 +41,7 @@ public final class RawField implements Field {
     private final int delimiterIdx;
     private final String name;
     private final String body;
+    private String nameLowerCase;
 
     RawField(ByteSequence raw, int delimiterIdx, String name, String body) {
         if (name == null) {
@@ -60,6 +63,14 @@ public final class RawField implements Field {
 
     public String getName() {
         return name;
+    }
+
+    @Override
+    public String getNameLowerCase() {
+        if (nameLowerCase == null) {
+            nameLowerCase = name.toLowerCase(Locale.US);
+        }
+        return nameLowerCase;
     }
 
     public String getBody() {

--- a/dom/src/main/java/org/apache/james/mime4j/dom/Message.java
+++ b/dom/src/main/java/org/apache/james/mime4j/dom/Message.java
@@ -442,7 +442,7 @@ public interface Message extends Entity, Body {
          * @return the identifier of this message.
          */
         public String getMessageId() {
-            Field field = obtainField(FieldName.MESSAGE_ID);
+            Field field = obtainField(FieldName.MESSAGE_ID_LOWERCASE);
             return field != null ? field.getBody() : null;
         }
 
@@ -484,7 +484,7 @@ public interface Message extends Entity, Body {
          * @return the subject of this message.
          */
         public String getSubject() {
-            UnstructuredField field = obtainField(FieldName.SUBJECT);
+            UnstructuredField field = obtainField(FieldName.SUBJECT_LOWERCASE);
             return field != null ? field.getValue() : null;
         }
 
@@ -513,7 +513,7 @@ public interface Message extends Entity, Body {
          * @return the date of this message.
          */
         public Date getDate() {
-            DateTimeField field = obtainField(FieldName.DATE);
+            DateTimeField field = obtainField(FieldName.DATE_LOWERCASE);
             return field != null ? field.getDate() : null;
         }
 
@@ -558,7 +558,7 @@ public interface Message extends Entity, Body {
          * @return the sender of this message.
          */
         public Mailbox getSender() {
-            return getMailbox(FieldName.SENDER);
+            return getMailbox(FieldName.SENDER_LOWERCASE);
         }
 
         /**
@@ -593,7 +593,7 @@ public interface Message extends Entity, Body {
          * @return value of the from field of this message.
          */
         public MailboxList getFrom() {
-            return getMailboxList(FieldName.FROM);
+            return getMailboxList(FieldName.FROM_LOWERCASE);
         }
 
         /**
@@ -664,7 +664,7 @@ public interface Message extends Entity, Body {
          * @return value of the to field of this message.
          */
         public AddressList getTo() {
-            return getAddressList(FieldName.TO);
+            return getAddressList(FieldName.TO_LOWERCASE);
         }
 
         /**
@@ -735,7 +735,7 @@ public interface Message extends Entity, Body {
          * @return value of the cc field of this message.
          */
         public AddressList getCc() {
-            return getAddressList(FieldName.CC);
+            return getAddressList(FieldName.CC_LOWERCASE);
         }
 
         /**
@@ -782,7 +782,7 @@ public interface Message extends Entity, Body {
          * @return value of the bcc field of this message.
          */
         public AddressList getBcc() {
-            return getAddressList(FieldName.BCC);
+            return getAddressList(FieldName.BCC_LOWERCASE);
         }
 
         /**
@@ -829,7 +829,7 @@ public interface Message extends Entity, Body {
          * @return value of the reply to field of this message.
          */
         public AddressList getReplyTo() {
-            return getAddressList(FieldName.REPLY_TO);
+            return getAddressList(FieldName.REPLY_TO_LOWERCASE);
         }
 
         /**
@@ -902,7 +902,7 @@ public interface Message extends Entity, Body {
             MessageImpl message = new MessageImpl();
             HeaderImpl header = new HeaderImpl();
             message.setHeader(header);
-            if (!containsField(FieldName.MIME_VERSION)) {
+            if (!containsField(FieldName.MIME_VERSION_LOWERCASE)) {
                 header.setField(Fields.version("1.0"));
             }
             for (Field field : getFields()) {

--- a/dom/src/main/java/org/apache/james/mime4j/dom/field/FieldName.java
+++ b/dom/src/main/java/org/apache/james/mime4j/dom/field/FieldName.java
@@ -19,15 +19,20 @@
 
 package org.apache.james.mime4j.dom.field;
 
+import java.util.Locale;
+
 /**
  * Constants for common header field names.
  */
 public class FieldName {
 
     public static final String CONTENT_TYPE = "Content-Type";
+    public static final String CONTENT_TYPE_LOWERCASE = CONTENT_TYPE.toLowerCase(Locale.US);
     public static final String CONTENT_LENGTH = "Content-Length";
     public static final String CONTENT_TRANSFER_ENCODING = "Content-Transfer-Encoding";
+    public static final String CONTENT_TRANSFER_ENCODING_LOWERCASE = CONTENT_TRANSFER_ENCODING.toLowerCase(Locale.US);
     public static final String CONTENT_DISPOSITION = "Content-Disposition";
+    public static final String CONTENT_DISPOSITION_LOWERCASE = CONTENT_DISPOSITION.toLowerCase(Locale.US);
     public static final String CONTENT_ID = "Content-ID";
     public static final String CONTENT_MD5 = "Content-MD5";
     public static final String CONTENT_DESCRIPTION = "Content-Description";
@@ -35,16 +40,26 @@ public class FieldName {
     public static final String CONTENT_LOCATION = "Content-Location";
 
     public static final String MIME_VERSION = "MIME-Version";
+    public static final String MIME_VERSION_LOWERCASE = MIME_VERSION.toLowerCase(Locale.US);
     public static final String DATE = "Date";
+    public static final String DATE_LOWERCASE = DATE.toLowerCase(Locale.US);
     public static final String MESSAGE_ID = "Message-ID";
+    public static final String MESSAGE_ID_LOWERCASE = MESSAGE_ID.toLowerCase(Locale.US);
     public static final String SUBJECT = "Subject";
+    public static final String SUBJECT_LOWERCASE = SUBJECT.toLowerCase(Locale.US);
 
     public static final String FROM = "From";
+    public static final String FROM_LOWERCASE = FROM.toLowerCase(Locale.US);
     public static final String SENDER = "Sender";
+    public static final String SENDER_LOWERCASE = SENDER.toLowerCase(Locale.US);
     public static final String TO = "To";
+    public static final String TO_LOWERCASE = TO.toLowerCase(Locale.US);
     public static final String CC = "Cc";
+    public static final String CC_LOWERCASE = CC.toLowerCase(Locale.US);
     public static final String BCC = "Bcc";
+    public static final String BCC_LOWERCASE = BCC.toLowerCase(Locale.US);
     public static final String REPLY_TO = "Reply-To";
+    public static final String REPLY_TO_LOWERCASE = REPLY_TO.toLowerCase(Locale.US);
 
     public static final String RESENT_DATE = "Resent-Date";
 

--- a/dom/src/main/java/org/apache/james/mime4j/field/AbstractField.java
+++ b/dom/src/main/java/org/apache/james/mime4j/field/AbstractField.java
@@ -49,6 +49,18 @@ public abstract class AbstractField implements ParsedField {
         return rawField.getName();
     }
 
+
+    /**
+     * Gets the name of the field in lower case (<code>subject</code>,
+     * <code>from</code>, etc).
+     *
+     * @return the field name.
+     */
+    @Override
+    public String getNameLowerCase() {
+        return rawField.getNameLowerCase();
+    }
+
     /**
      * Gets the unfolded, unparsed and possibly encoded (see RFC 2047) field
      * body string.

--- a/dom/src/main/java/org/apache/james/mime4j/field/DelegatingFieldParser.java
+++ b/dom/src/main/java/org/apache/james/mime4j/field/DelegatingFieldParser.java
@@ -55,8 +55,16 @@ public class DelegatingFieldParser implements FieldParser<ParsedField> {
         return field;
     }
 
+    private FieldParser<? extends ParsedField> getParser(final Field rawField) {
+        final FieldParser<? extends ParsedField> field = parsers.get(rawField.getNameLowerCase());
+        if (field == null) {
+            return defaultParser;
+        }
+        return field;
+    }
+
     public ParsedField parse(final Field rawField, final DecodeMonitor monitor) {
-        final FieldParser<? extends ParsedField> parser = getParser(rawField.getName());
+        final FieldParser<? extends ParsedField> parser = getParser(rawField);
         return parser.parse(rawField, monitor);
     }
 }

--- a/dom/src/main/java/org/apache/james/mime4j/internal/AbstractEntityBuilder.java
+++ b/dom/src/main/java/org/apache/james/mime4j/internal/AbstractEntityBuilder.java
@@ -256,7 +256,7 @@ public abstract class AbstractEntityBuilder {
      *         type has been set.
      */
     public String getMimeType() {
-        ContentTypeField field = obtainField(FieldName.CONTENT_TYPE);
+        ContentTypeField field = obtainField(FieldName.CONTENT_TYPE_LOWERCASE);
         return field != null ? field.getMimeType() : null;
     }
 
@@ -267,7 +267,7 @@ public abstract class AbstractEntityBuilder {
      *         type has been set.
      */
     public String getCharset() {
-        ContentTypeField field = obtainField(FieldName.CONTENT_TYPE);
+        ContentTypeField field = obtainField(FieldName.CONTENT_TYPE_LOWERCASE);
         return field != null ? field.getCharset() : null;
     }
 
@@ -293,7 +293,7 @@ public abstract class AbstractEntityBuilder {
      * @return the transfer encoding.
      */
     public String getContentTransferEncoding() {
-        ContentTransferEncodingField field = obtainField(FieldName.CONTENT_TRANSFER_ENCODING);
+        ContentTransferEncodingField field = obtainField(FieldName.CONTENT_TRANSFER_ENCODING_LOWERCASE);
         return field != null ? field.getEncoding() : null;
     }
 
@@ -319,7 +319,7 @@ public abstract class AbstractEntityBuilder {
      *         type has been set.
      */
     public String getDispositionType() {
-        ContentDispositionField field = obtainField(FieldName.CONTENT_DISPOSITION);
+        ContentDispositionField field = obtainField(FieldName.CONTENT_DISPOSITION_LOWERCASE);
         return field != null ? field.getDispositionType() : null;
     }
 
@@ -428,7 +428,7 @@ public abstract class AbstractEntityBuilder {
      *         <code>null</code> if the filename has not been set.
      */
     public String getFilename() {
-        ContentDispositionField field = obtainField(FieldName.CONTENT_DISPOSITION);
+        ContentDispositionField field = obtainField(FieldName.CONTENT_DISPOSITION_LOWERCASE);
         return field != null ? field.getFilename() : null;
     }
 
@@ -439,7 +439,7 @@ public abstract class AbstractEntityBuilder {
      *         <code>-1</code> if the filename has not been set.
      */
     public long getSize() {
-        ContentDispositionField field = obtainField(FieldName.CONTENT_DISPOSITION);
+        ContentDispositionField field = obtainField(FieldName.CONTENT_DISPOSITION_LOWERCASE);
         return field != null ? field.getSize() : -1;
     }
 
@@ -450,7 +450,7 @@ public abstract class AbstractEntityBuilder {
      *         <code>null</code> if the filename has not been set.
      */
     public Date getCreationDate() {
-        ContentDispositionField field = obtainField(FieldName.CONTENT_DISPOSITION);
+        ContentDispositionField field = obtainField(FieldName.CONTENT_DISPOSITION_LOWERCASE);
         return field != null ? field.getCreationDate() : null;
     }
 
@@ -461,7 +461,7 @@ public abstract class AbstractEntityBuilder {
      *         <code>null</code> if the filename has not been set.
      */
     public Date getModificationDate() {
-        ContentDispositionField field = obtainField(FieldName.CONTENT_DISPOSITION);
+        ContentDispositionField field = obtainField(FieldName.CONTENT_DISPOSITION_LOWERCASE);
         return field != null ? field.getModificationDate() : null;
     }
 
@@ -472,7 +472,7 @@ public abstract class AbstractEntityBuilder {
      *         <code>null</code> if the filename has not been set.
      */
     public Date getReadDate() {
-        ContentDispositionField field = obtainField(FieldName.CONTENT_DISPOSITION);
+        ContentDispositionField field = obtainField(FieldName.CONTENT_DISPOSITION_LOWERCASE);
         return field != null ? field.getReadDate() : null;
     }
 

--- a/dom/src/main/java/org/apache/james/mime4j/internal/AbstractEntityBuilder.java
+++ b/dom/src/main/java/org/apache/james/mime4j/internal/AbstractEntityBuilder.java
@@ -65,7 +65,7 @@ public abstract class AbstractEntityBuilder {
      * @param field the field to add.
      */
     public AbstractEntityBuilder addField(Field field) {
-        String lowerCasedFieldName = field.getName().toLowerCase(Locale.US);
+        String lowerCasedFieldName = field.getNameLowerCase();
         List<Field> values = fieldMap.get(lowerCasedFieldName);
         if (values == null) {
             values = new LinkedList<Field>();
@@ -210,7 +210,7 @@ public abstract class AbstractEntityBuilder {
      * @param field the field to set.
      */
     public AbstractEntityBuilder setField(Field field) {
-        final String lowerCaseName = field.getName().toLowerCase(Locale.US);
+        final String lowerCaseName = field.getNameLowerCase();
         List<Field> l = fieldMap.get(lowerCaseName);
         if (l == null || l.isEmpty()) {
             addField(field);

--- a/dom/src/main/java/org/apache/james/mime4j/message/AbstractEntity.java
+++ b/dom/src/main/java/org/apache/james/mime4j/message/AbstractEntity.java
@@ -126,12 +126,12 @@ public abstract class AbstractEntity implements Entity {
     public String getMimeType() {
         ContentTypeField childType = getContentTypeField();
         Entity parent = getParent();
-        ContentTypeField parentType = parent != null ? (ContentTypeField) (parent).getHeader().getField(FieldName.CONTENT_TYPE) : null;
+        ContentTypeField parentType = parent != null ? (ContentTypeField) (parent).getHeader().getField(FieldName.CONTENT_TYPE_LOWERCASE) : null;
         return calcMimeType(childType, parentType);
     }
 
     private ContentTypeField getContentTypeField() {
-        return (ContentTypeField) getHeader().getField(FieldName.CONTENT_TYPE);
+        return (ContentTypeField) getHeader().getField(FieldName.CONTENT_TYPE_LOWERCASE);
     }
 
     /**
@@ -140,7 +140,7 @@ public abstract class AbstractEntity implements Entity {
      * @return the MIME character set encoding.
      */
     public String getCharset() {
-        return calcCharset((ContentTypeField) getHeader().getField(FieldName.CONTENT_TYPE));
+        return calcCharset((ContentTypeField) getHeader().getField(FieldName.CONTENT_TYPE_LOWERCASE));
     }
 
     /**

--- a/dom/src/main/java/org/apache/james/mime4j/message/AbstractHeader.java
+++ b/dom/src/main/java/org/apache/james/mime4j/message/AbstractHeader.java
@@ -67,7 +67,7 @@ public abstract class AbstractHeader implements Header {
      * @param field the field to add.
      */
     public void addField(Field field) {
-        String lowerCaseFieldName = field.getName().toLowerCase(Locale.US);
+        String lowerCaseFieldName = field.getNameLowerCase();
         List<Field> values = fieldMap.get(lowerCaseFieldName);
         if (values == null) {
             values = new LinkedList<Field>();
@@ -220,7 +220,7 @@ public abstract class AbstractHeader implements Header {
      * @param field the field to set.
      */
     public void setField(Field field) {
-        final String lowerCaseName = field.getName().toLowerCase(Locale.US);
+        final String lowerCaseName = field.getNameLowerCase();
         List<Field> l = fieldMap.get(lowerCaseName);
         if (l == null || l.isEmpty()) {
             addField(field);

--- a/dom/src/main/java/org/apache/james/mime4j/message/AbstractMessage.java
+++ b/dom/src/main/java/org/apache/james/mime4j/message/AbstractMessage.java
@@ -45,7 +45,7 @@ public abstract class AbstractMessage extends AbstractEntity implements Message 
      * @return the identifier of this message.
      */
     public String getMessageId() {
-        Field field = obtainField(FieldName.MESSAGE_ID);
+        Field field = obtainField(FieldName.MESSAGE_ID_LOWERCASE);
         if (field == null)
             return null;
 
@@ -59,7 +59,7 @@ public abstract class AbstractMessage extends AbstractEntity implements Message 
      * @return the subject of this message.
      */
     public String getSubject() {
-        UnstructuredField field = obtainField(FieldName.SUBJECT);
+        UnstructuredField field = obtainField(FieldName.SUBJECT_LOWERCASE);
         if (field == null)
             return null;
 
@@ -73,7 +73,7 @@ public abstract class AbstractMessage extends AbstractEntity implements Message 
      * @return the date of this message.
      */
     public Date getDate() {
-        DateTimeField dateField = obtainField(FieldName.DATE);
+        DateTimeField dateField = obtainField(FieldName.DATE_LOWERCASE);
         if (dateField == null)
             return null;
 
@@ -88,7 +88,7 @@ public abstract class AbstractMessage extends AbstractEntity implements Message 
      * @return the sender of this message.
      */
     public Mailbox getSender() {
-        return getMailbox(FieldName.SENDER);
+        return getMailbox(FieldName.SENDER_LOWERCASE);
     }
 
     /**
@@ -99,7 +99,7 @@ public abstract class AbstractMessage extends AbstractEntity implements Message 
      * @return value of the from field of this message.
      */
     public MailboxList getFrom() {
-        return getMailboxList(FieldName.FROM);
+        return getMailboxList(FieldName.FROM_LOWERCASE);
     }
 
     /**
@@ -110,7 +110,7 @@ public abstract class AbstractMessage extends AbstractEntity implements Message 
      * @return value of the to field of this message.
      */
     public AddressList getTo() {
-        return getAddressList(FieldName.TO);
+        return getAddressList(FieldName.TO_LOWERCASE);
     }
 
     /**
@@ -121,7 +121,7 @@ public abstract class AbstractMessage extends AbstractEntity implements Message 
      * @return value of the cc field of this message.
      */
     public AddressList getCc() {
-        return getAddressList(FieldName.CC);
+        return getAddressList(FieldName.CC_LOWERCASE);
     }
 
     /**
@@ -132,7 +132,7 @@ public abstract class AbstractMessage extends AbstractEntity implements Message 
      * @return value of the bcc field of this message.
      */
     public AddressList getBcc() {
-        return getAddressList(FieldName.BCC);
+        return getAddressList(FieldName.BCC_LOWERCASE);
     }
 
     /**
@@ -143,7 +143,7 @@ public abstract class AbstractMessage extends AbstractEntity implements Message 
      * @return value of the reply to field of this message.
      */
     public AddressList getReplyTo() {
-        return getAddressList(FieldName.REPLY_TO);
+        return getAddressList(FieldName.REPLY_TO_LOWERCASE);
     }
 
     private Mailbox getMailbox(String fieldName) {

--- a/dom/src/main/java/org/apache/james/mime4j/message/DefaultBodyDescriptorBuilder.java
+++ b/dom/src/main/java/org/apache/james/mime4j/message/DefaultBodyDescriptorBuilder.java
@@ -88,7 +88,7 @@ public class DefaultBodyDescriptorBuilder implements BodyDescriptorBuilder {
 
     public Field addField(final RawField rawfield) throws MimeException {
         ParsedField field = fieldParser.parse(rawfield, monitor);
-        String name = field.getName().toLowerCase(Locale.US);
+        String name = field.getNameLowerCase();
         if (!fields.containsKey(name)) {
             fields.put(name, field);
         }

--- a/dom/src/main/java/org/apache/james/mime4j/message/DefaultMessageWriter.java
+++ b/dom/src/main/java/org/apache/james/mime4j/message/DefaultMessageWriter.java
@@ -250,7 +250,7 @@ public class DefaultMessageWriter implements MessageWriter {
                     "Missing header in parent entity");
 
         ContentTypeField contentType = (ContentTypeField) header
-                .getField(FieldName.CONTENT_TYPE);
+                .getField(FieldName.CONTENT_TYPE_LOWERCASE);
         if (contentType == null)
             throw new IllegalArgumentException(
                     "Content-Type field not specified");


### PR DESCRIPTION
## Before

![mime4j-302-before](https://user-images.githubusercontent.com/6928740/122512595-49808100-d033-11eb-8d2b-0ed8458b697b.png)

18% of CPU time of Message.Builder.parse is held by toLowerCase calls.

## After

![mime4j-302-after](https://user-images.githubusercontent.com/6928740/122512676-66b54f80-d033-11eb-92d4-3d8e6ac1c43d.png)

6,75% of CPU is used by toLowerCase calls...