### PR TITLE
MIME-298 DateTimeFieldLenientImpl: remove unneeded option

### DIFF
--- a/dom/src/main/java/org/apache/james/mime4j/field/DateTimeFieldLenientImpl.java
+++ b/dom/src/main/java/org/apache/james/mime4j/field/DateTimeFieldLenientImpl.java
@@ -36,8 +36,6 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.ResolverStyle;
 import java.time.format.SignStyle;
-import java.time.temporal.ChronoField;
-import java.time.temporal.TemporalField;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
@@ -84,10 +82,6 @@ public class DateTimeFieldLenientImpl extends AbstractField implements DateTimeF
         .optionalStart()
             .appendLiteral(' ')
             .appendOffsetId()
-        .optionalEnd()
-        .optionalStart()
-            .appendLiteral(' ')
-            .appendPattern("0000")
         .optionalEnd()
         .toFormatter()
         .withZone(ZoneId.of("GMT"))


### PR DESCRIPTION
Removing it breaks no tests, as 0000 is the
default GMT.

This prevents one defensive copy of the
parsed entity thus gets parsing slightly
faster.