### PR TITLE
MIME4J-305 ContentUtil::decode can avoid using StringBuilder

### DIFF
--- a/core/src/main/java/org/apache/james/mime4j/util/ContentUtil.java
+++ b/core/src/main/java/org/apache/james/mime4j/util/ContentUtil.java
@@ -176,11 +176,11 @@ public class ContentUtil {
         if (byteSequence == null) {
             return null;
         }
-        StringBuilder buf = new StringBuilder(length);
+        char[] underlying = new char[length];
         for (int i = offset; i < offset + length; i++) {
-            buf.append((char) (byteSequence.byteAt(i) & 0xff));
+            underlying[i - offset] = (char) (byteSequence.byteAt(i) & 0xff);
         }
-        return buf.toString();
+        return new String(underlying);
     }
 
     /**


### PR DESCRIPTION
StringBuilder is an expensive construct, we spend most of our time, for each character, ensuring the capacity of the string builder.

Size being known, the operation simple, we can directly operate on top of a char array.

Gains: 78%

## Before

![before_decode](https://user-images.githubusercontent.com/6928740/127516171-72b7d978-9185-43ba-9c69-0e71e7df1e81.png)

## After

![after_decode](https://user-images.githubusercontent.com/6928740/127516203-09d82037-59fd-4737-a1f0-ec44e31b5ced.png)

(combine with MIME4J-304 and unfold operations)
