### PR TITLE
MIME4J-306 MimeUtil::unfold should group char appends

### DIFF
--- a/core/src/main/java/org/apache/james/mime4j/util/MimeUtil.java
+++ b/core/src/main/java/org/apache/james/mime4j/util/MimeUtil.java
@@ -263,11 +263,18 @@ public final class MimeUtil {
             sb.append(s, 0, crlfIdx);
         }
 
+        int lastLineBreak = crlfIdx;
         for (int idx = crlfIdx + 1; idx < length; idx++) {
             char c = s.charAt(idx);
-            if (c != '\r' && c != '\n') {
-                sb.append(c);
+            if (c == '\r' || c == '\n') {
+                if (idx > lastLineBreak + 1) {
+                    sb.append(s, lastLineBreak + 1, idx);
+                }
+                lastLineBreak = idx;
             }
+        }
+        if (lastLineBreak < s.length() - 1 && s.length() > 0) {
+            sb.append(s, lastLineBreak + 1, s.length());
         }
 
         return sb.toString();


### PR DESCRIPTION
Calling repeatedly append requires ensuring the capacity amongst other.

Appends to the string builder can be done for all previous chars when a line delimiter is encountered, thus reducing the cost of the operation.

Gain: 66%

## Before

![before_unfold](https://user-images.githubusercontent.com/6928740/127517183-3a54357b-925c-49dd-94f6-b8bfa8c2c529.png)

## After

![after_unfold](https://user-images.githubusercontent.com/6928740/127517212-035ec0c9-199a-4cd7-b70d-8a6957f99226.png)
