### PR TITLE
MIME4J-307 AbstractHeader::getField (with cast) should handle missing…

### DIFF
--- a/dom/src/main/java/org/apache/james/mime4j/message/AbstractHeader.java
+++ b/dom/src/main/java/org/apache/james/mime4j/message/AbstractHeader.java
@@ -125,6 +125,9 @@ public abstract class AbstractHeader implements Header {
      */
     public <F extends Field> F getField(final String name, final Class<F> clazz) {
         List<Field> l = fieldMap.get(name.toLowerCase(Locale.US));
+        if (l == null) {
+            return null;
+        }
         for (int i = 0; i < l.size(); i++) {
             Field field = l.get(i);
             if (clazz.isInstance(field)) {

--- a/dom/src/test/java/org/apache/james/mime4j/dom/MessageTest.java
+++ b/dom/src/test/java/org/apache/james/mime4j/dom/MessageTest.java
@@ -32,6 +32,7 @@ import org.apache.james.mime4j.dom.address.Mailbox;
 import org.apache.james.mime4j.dom.address.MailboxList;
 import org.apache.james.mime4j.dom.field.ContentTypeField;
 import org.apache.james.mime4j.dom.field.FieldName;
+import org.apache.james.mime4j.dom.field.MailboxField;
 import org.apache.james.mime4j.field.DefaultFieldParser;
 import org.apache.james.mime4j.field.Fields;
 import org.apache.james.mime4j.field.address.DefaultAddressParser;
@@ -430,6 +431,19 @@ public class MessageTest {
         Assert.assertEquals(original.getHeader().getFields(), builder.getFields());
         Assert.assertNotSame(original.getBody(), builder.getBody());
         Assert.assertSame(original.getBody().getClass(), builder.getBody().getClass());
+    }
+
+    @Test
+    public void getFieldShouldReturnNullOnMissingHeader() throws Exception {
+        Message original = Message.Builder.of()
+                .generateMessageId("hostname")
+                .setSubject("testing ...")
+                .setFrom("batman@localhost", "superman@localhost")
+                .setTo("\"Big momma\" <big_momma@localhost>")
+                .setBody("Yo, big momma!", Charsets.UTF_8)
+                .build();
+
+        Assert.assertNull(original.getHeader().getField("Sender", MailboxField.class));
     }
 
 }


### PR DESCRIPTION
… header