### PR TITLE
MIME4J-310 Force using Buffer.flip

### DIFF
--- a/core/src/main/java/org/apache/james/mime4j/io/TextInputStream.java
+++ b/core/src/main/java/org/apache/james/mime4j/io/TextInputStream.java
@@ -21,6 +21,7 @@ package org.apache.james.mime4j.io;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.CharacterCodingException;
@@ -46,7 +47,9 @@ class TextInputStream extends InputStream {
             .onMalformedInput(CodingErrorAction.REPLACE)
             .onUnmappableCharacter(CodingErrorAction.REPLACE);
         this.bbuf = ByteBuffer.allocate(bufferSize);
-        this.bbuf.flip();
+        // Compatibility Java 8 cf MIME4J-310
+        // https://stackoverflow.com/questions/61267495/exception-in-thread-main-java-lang-nosuchmethoderror-java-nio-bytebuffer-flip
+        ((Buffer) this.bbuf).flip();
         this.cbuf = CharBuffer.wrap(s);
     }
 
@@ -56,7 +59,9 @@ class TextInputStream extends InputStream {
         if (result.isError()) {
             result.throwException();
         }
-        this.bbuf.flip();
+        // Compatibility Java 8 cf MIME4J-310
+        // https://stackoverflow.com/questions/61267495/exception-in-thread-main-java-lang-nosuchmethoderror-java-nio-bytebuffer-flip
+        ((Buffer) this.bbuf).flip();
     }
 
     @Override

--- a/dom/src/main/java/org/apache/james/mime4j/field/DateTimeFieldLenientImpl.java
+++ b/dom/src/main/java/org/apache/james/mime4j/field/DateTimeFieldLenientImpl.java
@@ -169,9 +169,9 @@ public class DateTimeFieldLenientImpl extends AbstractField implements DateTimeF
         }
         try {
             if (JAVA_8_COMPATIBILITY_MODE) {
-                date = Date.from(Instant.from(RFC_5322.parse(body, new ParsePosition(0))));
-            } else {
                 compatibilityWithJava8(body);
+            } else {
+                date = Date.from(Instant.from(RFC_5322.parse(body, new ParsePosition(0))));
             }
         } catch (Exception e) {
             // Ignore


### PR DESCRIPTION
ByteBuffer.flip is only implemented from JDK11 onward. Please note that issue
arise when compiling with a JDK 11 and running with a JDK 8 despite maven
target and sources releases.