### PR TITLE
fix: use correct character encoding when parsing of MIME parameter value

### DIFF
--- a/core/src/main/java/org/apache/james/mime4j/util/MimeParameterMapping.java
+++ b/core/src/main/java/org/apache/james/mime4j/util/MimeParameterMapping.java
@@ -45,6 +45,9 @@ public class MimeParameterMapping {
     }
 
     private String decodeParameterValue(String value) {
+        if (value == null) {
+            return null;
+        }
         int charsetEnd = value.indexOf("'");
         int languageEnd = value.indexOf("'", charsetEnd + 1);
         if (charsetEnd < 0 || languageEnd < 0) {

--- a/core/src/main/java/org/apache/james/mime4j/util/MimeParameterMapping.java
+++ b/core/src/main/java/org/apache/james/mime4j/util/MimeParameterMapping.java
@@ -17,18 +17,17 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.mime4j.internal;
+package org.apache.james.mime4j.util;
 
 import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.james.mime4j.util.MimeUtil;
 
-public class ParameterHelper {
+public class MimeParameterMapping {
 
     private final Map<String, String> parameters = new HashMap<>();
 
-    public Map<String,String> getParameters() {
+    public Map<String, String> getParameters() {
         Map<String,String> result = new HashMap<>();
         for (Map.Entry<String, String > entry : parameters.entrySet()) {
             result.put(entry.getKey(), decodeParameterValue(entry.getValue()) );
@@ -36,7 +35,7 @@ public class ParameterHelper {
         return result;
     }
 
-    public void addParameterValue(String name, String value) {
+    public void addParameter(String name, String value) {
         String key = removeSectionFromName(name).toLowerCase();
         if (parameters.containsKey(key)) {
             parameters.put(key, parameters.get(key) + value);
@@ -45,7 +44,7 @@ public class ParameterHelper {
         }
     }
 
-    private static String decodeParameterValue(String value) {
+    private String decodeParameterValue(String value) {
         int charsetEnd = value.indexOf("'");
         int languageEnd = value.indexOf("'", charsetEnd + 1);
         if (charsetEnd < 0 || languageEnd < 0) {
@@ -61,7 +60,7 @@ public class ParameterHelper {
         return MimeUtil.unscrambleHeaderValue(value);
     }
 
-    private static String removeSectionFromName(String parameterName) {
+    private String removeSectionFromName(String parameterName) {
         int position = parameterName.indexOf('*');
         return parameterName.substring(0, position < 0 ? parameterName.length() : position);
     }

--- a/dom/src/main/java/org/apache/james/mime4j/field/ContentDispositionFieldImpl.java
+++ b/dom/src/main/java/org/apache/james/mime4j/field/ContentDispositionFieldImpl.java
@@ -23,7 +23,6 @@ import java.io.StringReader;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -231,20 +230,8 @@ public class ContentDispositionFieldImpl extends AbstractField implements Conten
 
         if (dispositionType != null) {
             this.dispositionType = dispositionType.toLowerCase(Locale.US);
-
-            List<String> paramNames = parser.getParamNames();
-            List<String> paramValues = parser.getParamValues();
-
-            if (paramNames != null && paramValues != null) {
-                final int len = Math.min(paramNames.size(), paramValues.size());
-                for (int i = 0; i < len; i++) {
-                    String paramName = paramNames.get(i).toLowerCase(Locale.US);
-                    String paramValue = paramValues.get(i);
-                    parameters.put(paramName, paramValue);
-                }
-            }
+            this.parameters.putAll(parser.getParameters());
         }
-
         parsed = true;
     }
 

--- a/dom/src/main/java/org/apache/james/mime4j/field/ContentDispositionFieldLenientImpl.java
+++ b/dom/src/main/java/org/apache/james/mime4j/field/ContentDispositionFieldLenientImpl.java
@@ -39,6 +39,7 @@ import org.apache.james.mime4j.stream.NameValuePair;
 import org.apache.james.mime4j.stream.RawBody;
 import org.apache.james.mime4j.stream.RawField;
 import org.apache.james.mime4j.stream.RawFieldParser;
+import org.apache.james.mime4j.util.MimeParameterMapping;
 
 /**
  * Represents a <code>Content-Disposition</code> field.
@@ -168,9 +169,12 @@ public class ContentDispositionFieldLenientImpl extends AbstractField implements
             dispositionType = null;
         }
         parameters.clear();
-        for (NameValuePair nmp: body.getParams()) {
-            String name = nmp.getName().toLowerCase(Locale.US);
-            parameters.put(name, nmp.getValue());
+        MimeParameterMapping mapping = new MimeParameterMapping();
+        for (NameValuePair pair : body.getParams()) {
+            mapping.addParameter(pair.getName(), pair.getValue());
+        }
+        for (Map.Entry<String, String> entry : mapping.getParameters().entrySet()) {
+            parameters.put(entry.getKey(), entry.getValue());
         }
     }
 

--- a/dom/src/main/java/org/apache/james/mime4j/internal/ParameterHelper.java
+++ b/dom/src/main/java/org/apache/james/mime4j/internal/ParameterHelper.java
@@ -1,0 +1,68 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mime4j.internal;
+
+import java.io.UnsupportedEncodingException;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.james.mime4j.util.MimeUtil;
+
+public class ParameterHelper {
+
+    private final Map<String, String> parameters = new HashMap<>();
+
+    public Map<String,String> getParameters() {
+        Map<String,String> result = new HashMap<>();
+        for (Map.Entry<String, String > entry : parameters.entrySet()) {
+            result.put(entry.getKey(), decodeParameterValue(entry.getValue()) );
+        }
+        return result;
+    }
+
+    public void addParameterValue(String name, String value) {
+        String key = removeSectionFromName(name).toLowerCase();
+        if (parameters.containsKey(key)) {
+            parameters.put(key, parameters.get(key) + value);
+        } else {
+            parameters.put(key, value);
+        }
+    }
+
+    private static String decodeParameterValue(String value) {
+        int charsetEnd = value.indexOf("'");
+        int languageEnd = value.indexOf("'", charsetEnd + 1);
+        if (charsetEnd < 0 || languageEnd < 0) {
+            return MimeUtil.unscrambleHeaderValue(value);
+        }
+        String charset = value.substring(0, charsetEnd);
+        String fileName = value.substring(languageEnd + 1);
+        try {
+            return java.net.URLDecoder.decode(fileName, charset);
+        }
+        catch (UnsupportedEncodingException ignore) {
+        }
+        return MimeUtil.unscrambleHeaderValue(value);
+    }
+
+    private static String removeSectionFromName(String parameterName) {
+        int position = parameterName.indexOf('*');
+        return parameterName.substring(0, position < 0 ? parameterName.length() : position);
+    }
+}

--- a/dom/src/main/javacc/org/apache/james/mime4j/field/contentdisposition/ContentDispositionParser.jj
+++ b/dom/src/main/javacc/org/apache/james/mime4j/field/contentdisposition/ContentDispositionParser.jj
@@ -52,25 +52,23 @@ PARSER_BEGIN(ContentDispositionParser)
  ****************************************************************/
 package org.apache.james.mime4j.field.contentdisposition.parser;
 
+import org.apache.james.mime4j.internal.ParameterHelper;
+import java.util.Map;
 import java.util.List;
 import java.util.ArrayList;
 
 public class ContentDispositionParser {
 
     private String dispositionType;
-    private List<String> paramNames = new ArrayList<String>();
-    private List<String> paramValues = new ArrayList<String>();
+
+    private final ParameterHelper parameters = new ParameterHelper();
 
     public String getDispositionType() {
         return dispositionType;
     }
 
-    public List<String> getParamNames() {
-        return paramNames;
-    }
-
-    public List<String> getParamValues() {
-        return paramValues;
+    public Map<String, String> getParameters() {
+        return parameters.getParameters();
     }
 
     public static void main(String args[]) throws ParseException {
@@ -121,8 +119,7 @@ void parameter() :
 {
 	attrib=<ATOKEN> "=" val=value()
 	{
-		paramNames.add(attrib.image);
-		paramValues.add(val);
+        parameters.addParameterValue(attrib.image, val);
 	}
 }
 

--- a/dom/src/main/javacc/org/apache/james/mime4j/field/contentdisposition/ContentDispositionParser.jj
+++ b/dom/src/main/javacc/org/apache/james/mime4j/field/contentdisposition/ContentDispositionParser.jj
@@ -52,23 +52,21 @@ PARSER_BEGIN(ContentDispositionParser)
  ****************************************************************/
 package org.apache.james.mime4j.field.contentdisposition.parser;
 
-import org.apache.james.mime4j.internal.ParameterHelper;
+import org.apache.james.mime4j.util.MimeParameterMapping;
 import java.util.Map;
-import java.util.List;
-import java.util.ArrayList;
 
 public class ContentDispositionParser {
 
     private String dispositionType;
 
-    private final ParameterHelper parameters = new ParameterHelper();
+    private final MimeParameterMapping mapping = new MimeParameterMapping();
 
     public String getDispositionType() {
         return dispositionType;
     }
 
     public Map<String, String> getParameters() {
-        return parameters.getParameters();
+        return mapping.getParameters();
     }
 
     public static void main(String args[]) throws ParseException {
@@ -119,7 +117,7 @@ void parameter() :
 {
 	attrib=<ATOKEN> "=" val=value()
 	{
-        parameters.addParameterValue(attrib.image, val);
+        mapping.addParameter(attrib.image, val);
 	}
 }
 

--- a/dom/src/test/java/org/apache/james/mime4j/field/ContentDispositionFieldTest.java
+++ b/dom/src/test/java/org/apache/james/mime4j/field/ContentDispositionFieldTest.java
@@ -92,6 +92,13 @@ public class ContentDispositionFieldTest extends TestCase {
         assertFalse(f.isAttachment());
     }
 
+    private static String getMessage(ContentDispositionField field) {
+        if( field.getParseException() == null) {
+            return "";
+        }
+        return field.getParseException().getMessage() + " when parsing " + field.getRaw();
+    }
+
     public void testGetFilename() throws Exception {
         ContentDispositionField f = parse("Content-Disposition: inline; filename=yada.txt");
         assertEquals("yada.txt", f.getFilename());
@@ -105,6 +112,48 @@ public class ContentDispositionFieldTest extends TestCase {
         f = parse("Content-Disposition: inline");
         assertNull(f.getFilename());
     }
+
+    public void testNonAsciiFilename() throws MimeException {
+        ContentDispositionField f =
+                parse("Content-Disposition: attachment;"
+                        + "\nfilename*0=\"=?UTF-8?Q?3-2_FORPROSJEKT_2-Sheet_-_XXX_A_2_40_?="
+                        + "\n=?UTF-8?Q?\";"
+                        + "\nfilename*1=\"201_-_Fasader_nord=C3=B8st_og_nordvest.dwg?=\"");
+
+        assertEquals(getMessage(f),
+                "3-2 FORPROSJEKT 2-Sheet - XXX A 2 40 201 - Fasader nordøst og nordvest.dwg",
+                f.getFilename());
+    }
+
+    public void testExtendedNotation() throws MimeException {
+        ContentDispositionField f = parse("Content-Disposition: attachment;\n" +
+                " filename*=utf-8''%D8%AF%D9%8A%D9%86%D8%A7%D8%B5%D9%88%D8%B1%2E%6F%64%74");
+        String name = f.getFilename();
+        assertEquals(getMessage(f), "ديناصور.odt", name);
+    }
+
+    public void testExtendedNotationWithEmptyCharsetShouldNotCrash() throws MimeException {
+        String fileName = "''%D8%AF%D9%8A%D9%86%D8%A7%D8%B5%D9%88%D8%B1%2E%6F%64%74";
+        String fileNameString = String.format("\"Content-Disposition: attachment;\n" +
+                " \nfilename*=%s\"", fileName);
+        ContentDispositionField f = parse(fileNameString);
+        String name = f.getFilename();
+        assertEquals(getMessage(f), fileName, name);
+    }
+
+    public void testFileNameWithInitialSection() throws MimeException {
+        ContentDispositionField f = parse("Content-Disposition: attachment;"
+                + "\nfilename*0*=filename.txt");
+        assertEquals(getMessage(f),"filename.txt", f.getFilename());
+    }
+
+    public void testFileNameWithMultipleSections() throws MimeException {
+        ContentDispositionField f = parse("Content-Disposition: attachment;"
+                + "\nfilename*0=\"first part \"; filename*1=\"of long filename.txt\"");
+        f.getFilename();
+        assertEquals(getMessage(f),"first part of long filename.txt", f.getFilename());
+    }
+
 
     public void testGetCreationDate() throws Exception {
         ContentDispositionField f = parse("Content-Disposition: inline; "

--- a/dom/src/test/java/org/apache/james/mime4j/field/LenientContentDispositionFieldTest.java
+++ b/dom/src/test/java/org/apache/james/mime4j/field/LenientContentDispositionFieldTest.java
@@ -185,7 +185,8 @@ public class LenientContentDispositionFieldTest {
                 "ooooooooooooooong_fiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiileeeeeeeeeeeeeeeeeeeeeeeeeeeeee" +
                 "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee.txt", f.getFilename());
     }
-    
+
+    @Test
     public void testNonAsciiFilename() throws MimeException {
          ContentDispositionField f = parse("Content-Disposition: attachment;"
                         + "\nfilename*0=\"=?UTF-8?Q?3-2_FORPROSJEKT_2-Sheet_-_XXX_A_2_40_?="

--- a/dom/src/test/java/org/apache/james/mime4j/field/LenientContentDispositionFieldTest.java
+++ b/dom/src/test/java/org/apache/james/mime4j/field/LenientContentDispositionFieldTest.java
@@ -192,8 +192,7 @@ public class LenientContentDispositionFieldTest {
                         + "\n=?UTF-8?Q?\";"
                         + "\nfilename*1=\"201_-_Fasader_nord=C3=B8st_og_nordvest.dwg?=\"");
 
-        assertEquals(getMessage(f),
-                "3-2 FORPROSJEKT 2-Sheet - XXX A 2 40 201 - Fasader nordøst og nordvest.dwg",
+        Assert.assertEquals("3-2 FORPROSJEKT 2-Sheet - XXX A 2 40 201 - Fasader nordøst og nordvest.dwg",
                 f.getFilename());
     }
 

--- a/dom/src/test/java/org/apache/james/mime4j/field/LenientContentDispositionFieldTest.java
+++ b/dom/src/test/java/org/apache/james/mime4j/field/LenientContentDispositionFieldTest.java
@@ -185,5 +185,16 @@ public class LenientContentDispositionFieldTest {
                 "ooooooooooooooong_fiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiileeeeeeeeeeeeeeeeeeeeeeeeeeeeee" +
                 "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee.txt", f.getFilename());
     }
+    
+    public void testNonAsciiFilename() throws MimeException {
+         ContentDispositionField f = parse("Content-Disposition: attachment;"
+                        + "\nfilename*0=\"=?UTF-8?Q?3-2_FORPROSJEKT_2-Sheet_-_XXX_A_2_40_?="
+                        + "\n=?UTF-8?Q?\";"
+                        + "\nfilename*1=\"201_-_Fasader_nord=C3=B8st_og_nordvest.dwg?=\"");
+
+        assertEquals(getMessage(f),
+                "3-2 FORPROSJEKT 2-Sheet - XXX A 2 40 201 - Fasader nordøst og nordvest.dwg",
+                f.getFilename());
+    }
 
 }

--- a/dom/src/test/java/org/apache/james/mime4j/field/LenientContentDispositionFieldTest.java
+++ b/dom/src/test/java/org/apache/james/mime4j/field/LenientContentDispositionFieldTest.java
@@ -174,4 +174,16 @@ public class LenientContentDispositionFieldTest {
         Assert.assertEquals(12, f.getSize());
     }
 
+    @Test
+    public void testMultipartFileName() throws Exception {
+        ContentDispositionField f = parse("Content-Disposition: attachment;\n" +
+                " filename*0=\"looooooooooooooooooooooooooooooooooooooooooooooooooooooooooo\";\n" +
+                " filename*1=\"oooooooooooooooooooooooooooooooooooooong_fiiiiiiiiiiiiiiiiii\";\n" +
+                " filename*2=\"iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiileeeeeeeeeeeeeeeeeee\";\n" +
+                " filename*3=\"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee.txt\"");
+        Assert.assertEquals("loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo" +
+                "ooooooooooooooong_fiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiileeeeeeeeeeeeeeeeeeeeeeeeeeeeee" +
+                "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee.txt", f.getFilename());
+    }
+
 }


### PR DESCRIPTION
Hello, I'm proposing fixes for MIME4J-109. As suggested [pull64](https://github.com/apache/james-mime4j/pull/64) is closed and this one is created based on the code review. please let me know if any clarification is needed. Thanks