### PR TITLE
MIME4J-318 Buffer recycling and memory efficiency

### DIFF
--- a/benchmark/src/main/java/org/apache/james/mime4j/LongMultipartReadBench.java
+++ b/benchmark/src/main/java/org/apache/james/mime4j/LongMultipartReadBench.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import org.apache.james.mime4j.dom.Header;
+import org.apache.james.mime4j.dom.Message;
 import org.apache.james.mime4j.dom.MessageBuilder;
 import org.apache.james.mime4j.message.DefaultMessageBuilder;
 import org.apache.james.mime4j.message.SimpleContentHandler;
@@ -174,7 +175,8 @@ public class LongMultipartReadBench {
             MessageBuilder builder = new DefaultMessageBuilder();
 
             for (int i = 0; i < repetitions; i++) {
-                builder.parseMessage(new ByteArrayInputStream(content));
+                Message message = builder.parseMessage(new ByteArrayInputStream(content));
+                message.dispose();
             }
         }
     }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -41,7 +41,6 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/core/src/main/java/org/apache/james/mime4j/codec/QuotedPrintableInputStream.java
+++ b/core/src/main/java/org/apache/james/mime4j/codec/QuotedPrintableInputStream.java
@@ -21,13 +21,29 @@ package org.apache.james.mime4j.codec;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.ref.SoftReference;
 
+import org.apache.james.mime4j.util.BufferRecycler;
 import org.apache.james.mime4j.util.ByteArrayBuffer;
+import org.apache.james.mime4j.util.RecycledByteArrayBuffer;
 
 /**
  * Performs Quoted-Printable decoding on an underlying stream.
  */
 public class QuotedPrintableInputStream extends InputStream {
+    protected static final ThreadLocal<SoftReference<BufferRecycler>> _recyclerRef = new ThreadLocal<>();
+
+    public static BufferRecycler getBufferRecycler() {
+        SoftReference<BufferRecycler> ref = _recyclerRef.get();
+        BufferRecycler br = (ref == null) ? null : ref.get();
+
+        if (br == null) {
+            br = new BufferRecycler();
+            ref = new SoftReference<>(br);
+            _recyclerRef.set(ref);
+        }
+        return br;
+    }
 
     private static final int DEFAULT_BUFFER_SIZE = 1024 * 2;
 
@@ -38,8 +54,8 @@ public class QuotedPrintableInputStream extends InputStream {
     private final byte[] singleByte = new byte[1];
 
     private final InputStream in;
-    private final ByteArrayBuffer decodedBuf;
-    private final ByteArrayBuffer blanks;
+    private final RecycledByteArrayBuffer decodedBuf;
+    private final RecycledByteArrayBuffer blanks;
 
     private final byte[] encoded;
     private int pos = 0; // current index into encoded buffer
@@ -57,9 +73,10 @@ public class QuotedPrintableInputStream extends InputStream {
     protected QuotedPrintableInputStream(final int bufsize, final InputStream in, DecodeMonitor monitor) {
         super();
         this.in = in;
-        this.encoded = new byte[bufsize];
-        this.decodedBuf = new ByteArrayBuffer(512);
-        this.blanks = new ByteArrayBuffer(512);
+        BufferRecycler recycler = getBufferRecycler();
+        this.encoded = recycler.allocByteBuffer(1, bufsize);
+        this.decodedBuf = new RecycledByteArrayBuffer(recycler, 512);
+        this.blanks = new RecycledByteArrayBuffer(recycler, 512);
         this.closed = false;
         this.monitor = monitor;
     }
@@ -79,12 +96,13 @@ public class QuotedPrintableInputStream extends InputStream {
     /**
      * Terminates Quoted-Printable coded content. This method does NOT close
      * the underlying input stream.
-     *
-     * @throws IOException on I/O errors.
      */
     @Override
-    public void close() throws IOException {
+    public void close() {
         closed = true;
+        getBufferRecycler().releaseByteBuffer(1, encoded);
+        decodedBuf.release();
+        blanks.release();
     }
 
     private int fillBuffer() throws IOException {

--- a/core/src/main/java/org/apache/james/mime4j/io/BufferedLineReaderInputStream.java
+++ b/core/src/main/java/org/apache/james/mime4j/io/BufferedLineReaderInputStream.java
@@ -19,16 +19,32 @@
 
 package org.apache.james.mime4j.io;
 
+import org.apache.james.mime4j.util.BufferRecycler;
 import org.apache.james.mime4j.util.ByteArrayBuffer;
+import org.apache.james.mime4j.util.RecycledByteArrayBuffer;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.ref.SoftReference;
 
 /**
  * Input buffer that can be used to search for patterns using Quick Search
  * algorithm in data read from an {@link InputStream}.
  */
 public class BufferedLineReaderInputStream extends LineReaderInputStream {
+    protected static final ThreadLocal<SoftReference<BufferRecycler>> _recyclerRef = new ThreadLocal<>();
+
+    public static BufferRecycler getBufferRecycler() {
+        SoftReference<BufferRecycler> ref = _recyclerRef.get();
+        BufferRecycler br = (ref == null) ? null : ref.get();
+
+        if (br == null) {
+            br = new BufferRecycler();
+            ref = new SoftReference<>(br);
+            _recyclerRef.set(ref);
+        }
+        return br;
+    }
 
     private boolean truncated;
 
@@ -56,12 +72,13 @@ public class BufferedLineReaderInputStream extends LineReaderInputStream {
         if (buffersize <= 0) {
             throw new IllegalArgumentException("Buffer size may not be negative or zero");
         }
-        this.buffer = new byte[buffersize];
+        BufferRecycler bufferRecycler = getBufferRecycler();
+        this.buffer = bufferRecycler.allocByteBuffer(0, buffersize);
         this.bufpos = 0;
         this.buflen = 0;
         this.maxLineLen = maxLineLen;
         this.truncated = false;
-        this.shiftTable = new int[256];
+        this.shiftTable = bufferRecycler.allocintBuffer(256);
     }
 
     public BufferedLineReaderInputStream(
@@ -130,6 +147,12 @@ public class BufferedLineReaderInputStream extends LineReaderInputStream {
     public void truncate() {
         clear();
         this.truncated = true;
+    }
+
+    public void release() {
+        BufferRecycler bufferRecycler = getBufferRecycler();
+        bufferRecycler.releaseByteBuffer(0, buffer);
+        bufferRecycler.releaseIntBuffer(shiftTable);
     }
 
     protected boolean readAllowed() {
@@ -377,6 +400,19 @@ public class BufferedLineReaderInputStream extends LineReaderInputStream {
 
     @Override
     public boolean unread(ByteArrayBuffer buf) {
+        if (tempBuffer) return false;
+        origBuffer = buffer;
+        origBuflen = buflen;
+        origBufpos = bufpos;
+        bufpos = 0;
+        buflen = buf.length();
+        buffer = buf.buffer();
+        tempBuffer = true;
+        return true;
+    }
+
+    @Override
+    public boolean unread(RecycledByteArrayBuffer buf) {
         if (tempBuffer) return false;
         origBuffer = buffer;
         origBuflen = buflen;

--- a/core/src/main/java/org/apache/james/mime4j/io/BufferedLineReaderInputStream.java
+++ b/core/src/main/java/org/apache/james/mime4j/io/BufferedLineReaderInputStream.java
@@ -41,6 +41,7 @@ public class BufferedLineReaderInputStream extends LineReaderInputStream {
     private byte[] buffer;
     private int bufpos;
     private int buflen;
+    private int[] shiftTable;
 
     private final int maxLineLen;
 
@@ -60,6 +61,7 @@ public class BufferedLineReaderInputStream extends LineReaderInputStream {
         this.buflen = 0;
         this.maxLineLen = maxLineLen;
         this.truncated = false;
+        this.shiftTable = new int[256];
     }
 
     public BufferedLineReaderInputStream(
@@ -244,7 +246,7 @@ public class BufferedLineReaderInputStream extends LineReaderInputStream {
             return -1;
         }
 
-        int[] shiftTable = new int[256];
+
         for (int i = 0; i < shiftTable.length; i++) {
             shiftTable[i] = pattern.length + 1;
         }

--- a/core/src/main/java/org/apache/james/mime4j/io/LineReaderInputStream.java
+++ b/core/src/main/java/org/apache/james/mime4j/io/LineReaderInputStream.java
@@ -20,6 +20,7 @@
 package org.apache.james.mime4j.io;
 
 import org.apache.james.mime4j.util.ByteArrayBuffer;
+import org.apache.james.mime4j.util.RecycledByteArrayBuffer;
 
 import java.io.FilterInputStream;
 import java.io.IOException;
@@ -60,5 +61,6 @@ public abstract class LineReaderInputStream extends FilterInputStream {
      * @return true if the unread has been succesfull.
      */
     public abstract boolean unread(ByteArrayBuffer buf);
+    public abstract boolean unread(RecycledByteArrayBuffer buf);
 
 }

--- a/core/src/main/java/org/apache/james/mime4j/io/LineReaderInputStreamAdaptor.java
+++ b/core/src/main/java/org/apache/james/mime4j/io/LineReaderInputStreamAdaptor.java
@@ -20,6 +20,7 @@
 package org.apache.james.mime4j.io;
 
 import org.apache.james.mime4j.util.ByteArrayBuffer;
+import org.apache.james.mime4j.util.RecycledByteArrayBuffer;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -120,6 +121,11 @@ public class LineReaderInputStreamAdaptor extends LineReaderInputStream {
 
     @Override
     public boolean unread(ByteArrayBuffer buf) {
+        return bis != null && bis.unread(buf);
+    }
+
+    @Override
+    public boolean unread(RecycledByteArrayBuffer buf) {
         return bis != null && bis.unread(buf);
     }
 

--- a/core/src/main/java/org/apache/james/mime4j/io/MimeBoundaryInputStream.java
+++ b/core/src/main/java/org/apache/james/mime4j/io/MimeBoundaryInputStream.java
@@ -23,6 +23,7 @@ import org.apache.james.mime4j.MimeException;
 import org.apache.james.mime4j.MimeIOException;
 import org.apache.james.mime4j.util.ByteArrayBuffer;
 import org.apache.james.mime4j.util.CharsetUtil;
+import org.apache.james.mime4j.util.RecycledByteArrayBuffer;
 
 import java.io.IOException;
 
@@ -354,6 +355,11 @@ public class MimeBoundaryInputStream extends LineReaderInputStream {
 
     @Override
     public boolean unread(ByteArrayBuffer buf) {
+        return false;
+    }
+
+    @Override
+    public boolean unread(RecycledByteArrayBuffer buf) {
         return false;
     }
 }

--- a/core/src/main/java/org/apache/james/mime4j/parser/MimeStreamParser.java
+++ b/core/src/main/java/org/apache/james/mime4j/parser/MimeStreamParser.java
@@ -131,6 +131,7 @@ public class MimeStreamParser {
                         bodyContent = mimeTokenStream.getInputStream();
                     }
                     handler.body(desc, bodyContent);
+                    bodyContent.close();
                     break;
                 case T_END_BODYPART:
                     handler.endBodyPart();

--- a/core/src/main/java/org/apache/james/mime4j/stream/FieldBuilder.java
+++ b/core/src/main/java/org/apache/james/mime4j/stream/FieldBuilder.java
@@ -21,6 +21,7 @@ package org.apache.james.mime4j.stream;
 
 import org.apache.james.mime4j.MimeException;
 import org.apache.james.mime4j.util.ByteArrayBuffer;
+import org.apache.james.mime4j.util.RecycledByteArrayBuffer;
 
 /**
  * <p>
@@ -68,6 +69,8 @@ public interface FieldBuilder {
      * Returns combined content of all lines processed so far or <code>null</code>
      * if the builder does not retain original raw content.
      */
-    ByteArrayBuffer getRaw();
+    RecycledByteArrayBuffer getRaw();
+
+    void release();
 
 }

--- a/core/src/main/java/org/apache/james/mime4j/stream/MimeTokenStream.java
+++ b/core/src/main/java/org/apache/james/mime4j/stream/MimeTokenStream.java
@@ -258,7 +258,8 @@ public class MimeTokenStream {
      * triggered 'start' events.
      */
     public void stop() {
-        rootentity.stop();
+        rootentity.stopSoft();
+        fieldBuilder.release();
     }
 
     /**
@@ -380,7 +381,10 @@ public class MimeTokenStream {
             if (state != EntityState.T_END_OF_STREAM) {
                 return state;
             }
-            entities.removeLast();
+            final EntityStateMachine entityStateMachine = entities.removeLast();
+            if (entityStateMachine instanceof MimeEntity) {
+                ((MimeEntity) entityStateMachine).stop();
+            }
             if (entities.isEmpty()) {
                 currentStateMachine = null;
             } else {

--- a/core/src/main/java/org/apache/james/mime4j/stream/RawBody.java
+++ b/core/src/main/java/org/apache/james/mime4j/stream/RawBody.java
@@ -47,7 +47,7 @@ public final class RawBody {
     }
 
     public List<NameValuePair> getParams() {
-        return new ArrayList<NameValuePair>(this.params);
+        return this.params;
     }
 
     @Override

--- a/core/src/main/java/org/apache/james/mime4j/util/BufferRecycler.java
+++ b/core/src/main/java/org/apache/james/mime4j/util/BufferRecycler.java
@@ -19,11 +19,8 @@
 
 package org.apache.james.mime4j.util;
 
-import java.lang.ref.SoftReference;
 import java.util.ArrayList;
-import java.util.Random;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.Optional;
 
 /**
  * This is a small utility class, whose main functionality is to allow
@@ -37,6 +34,10 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
  * to not rely on {@code ThreadLocal} access.
  */
 public class BufferRecycler {
+    static final boolean ENABLED = Optional.ofNullable(System.getProperty("james.mime4j.buffer.recycling.enabled"))
+        .map(Boolean::parseBoolean)
+        .orElse(true);
+
     protected final ArrayList<byte[]>[] _byteBuffers;
     protected final ArrayList<char[]>[] _charBuffers;
     protected final ArrayList<int[]> _intBuffers;
@@ -122,7 +123,9 @@ public class BufferRecycler {
         if (buffer == null) {
             return;
         }
-        _intBuffers.add(buffer);
+        if (ENABLED) {
+            _intBuffers.add(buffer);
+        }
     }
     
     public final char[] allocCharBuffer(int ix) {
@@ -146,7 +149,9 @@ public class BufferRecycler {
     }
 
     public void releaseCharBuffer(int ix, char[] buffer) {
-        _charBuffers[ix].add(buffer);
+        if (ENABLED) {
+            _charBuffers[ix].add(buffer);
+        }
     }
 
     protected byte[] balloc(int size) {

--- a/core/src/main/java/org/apache/james/mime4j/util/BufferRecycler.java
+++ b/core/src/main/java/org/apache/james/mime4j/util/BufferRecycler.java
@@ -1,0 +1,159 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mime4j.util;
+
+import java.lang.ref.SoftReference;
+import java.util.ArrayList;
+import java.util.Random;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+/**
+ * This is a small utility class, whose main functionality is to allow
+ * simple reuse of raw byte/char buffers. It is usually used through
+ * <code>ThreadLocal</code> member of the owning class pointing to
+ * instance of this class through a <code>SoftReference</code>. The
+ * end result is a low-overhead GC-cleanable recycling: hopefully
+ * ideal for use by stream readers.
+ *<p>
+ * Rewritten in 2.10 to be thread-safe (see [jackson-core#479] for details),
+ * to not rely on {@code ThreadLocal} access.
+ */
+public class BufferRecycler {
+    protected final ArrayList<byte[]>[] _byteBuffers;
+    protected final ArrayList<char[]>[] _charBuffers;
+    protected final ArrayList<int[]> _intBuffers;
+
+    /**
+     * Default constructor used for creating instances of this default
+     * implementation.
+     */
+    public BufferRecycler() {
+        this(4, 4);
+    }
+
+    /**
+     * Alternate constructor to be used by sub-classes, to allow customization
+     * of number of low-level buffers in use.
+     *
+     * @param bbCount Number of {@code byte[]} buffers to allocate
+     * @param cbCount Number of {@code char[]} buffers to allocate
+     *
+     * @since 2.4
+     */
+    protected BufferRecycler(int bbCount, int cbCount) {
+        _byteBuffers = new ArrayList[bbCount];
+        for (int i = 0; i < bbCount; i++) {
+            _byteBuffers[i] = new ArrayList<>();
+        }
+        _charBuffers = new ArrayList[cbCount];
+        for (int i = 0; i < cbCount; i++) {
+            _charBuffers[i] = new ArrayList<>();
+        }
+        _intBuffers = new ArrayList<>();
+    }
+    
+    /**
+     * @param ix One of <code>READ_IO_BUFFER</code> constants.
+     *
+     * @return Buffer allocated (possibly recycled)
+     */
+    public final byte[] allocByteBuffer(int ix) {
+        return allocByteBuffer(ix, 0);
+    }
+
+    public final int[] allocintBuffer(int minSize) {
+        final int DEF_SIZE = 256;
+        if (minSize < DEF_SIZE) {
+            minSize = DEF_SIZE;
+        }
+        final ArrayList<int[]> buffers = _intBuffers;
+        int[] buffer = null;
+        if (buffers.size() > 0) {
+            buffer = buffers.remove(buffers.size() -1);
+        }
+        if (buffer == null || buffer.length < minSize) {
+            buffer = new int[minSize];
+        }
+        return buffer;
+    }
+
+    public byte[] allocByteBuffer(int ix, int minSize) {
+        final int DEF_SIZE = 4000;
+        if (minSize < DEF_SIZE) {
+            minSize = DEF_SIZE;
+        }
+        final ArrayList<byte[]> buffers = _byteBuffers[ix];
+        byte[] buffer = null;
+        if (buffers.size() > 0) {
+            buffer = buffers.remove(buffers.size() -1);
+        }
+        if (buffer == null || buffer.length < minSize) {
+            buffer = balloc(minSize);
+        }
+        return buffer;
+    }
+
+    public void releaseByteBuffer(int ix, byte[] buffer) {
+        if (buffer == null) {
+            return;
+        }
+        _byteBuffers[ix].add(buffer);
+    }
+
+    public void releaseIntBuffer(int[] buffer) {
+        if (buffer == null) {
+            return;
+        }
+        _intBuffers.add(buffer);
+    }
+    
+    public final char[] allocCharBuffer(int ix) {
+        return allocCharBuffer(ix, 0);
+    }
+
+    public char[] allocCharBuffer(int ix, int minSize) {
+        final int DEF_SIZE = 4000;
+        if (minSize < DEF_SIZE) {
+            minSize = DEF_SIZE;
+        }
+        final ArrayList<char[]> buffers = _charBuffers[ix];
+        char[] buffer = null;
+        if (buffers.size() > 0) {
+            buffer = buffers.remove(buffers.size() -1);
+        }
+        if (buffer == null || buffer.length < minSize) {
+            buffer = calloc(minSize);
+        }
+        return buffer;
+    }
+
+    public void releaseCharBuffer(int ix, char[] buffer) {
+        _charBuffers[ix].add(buffer);
+    }
+
+    protected byte[] balloc(int size) {
+        return new byte[size];
+    }
+
+    protected char[] calloc(int size) {
+        return new char[size];
+    }
+}

--- a/core/src/main/java/org/apache/james/mime4j/util/ByteArrayOutputStreamRecycler.java
+++ b/core/src/main/java/org/apache/james/mime4j/util/ByteArrayOutputStreamRecycler.java
@@ -58,7 +58,7 @@ public class ByteArrayOutputStreamRecycler {
     }
 
     private void release(UnsynchronizedByteArrayOutputStream value) {
-        if (value != null) {
+        if (value != null && BufferRecycler.ENABLED) {
             value.reset();
             buffers.offer(value);
         }

--- a/core/src/main/java/org/apache/james/mime4j/util/ByteArrayOutputStreamRecycler.java
+++ b/core/src/main/java/org/apache/james/mime4j/util/ByteArrayOutputStreamRecycler.java
@@ -1,0 +1,65 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mime4j.util;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import org.apache.commons.io.output.ByteArrayOutputStream;
+
+public class ByteArrayOutputStreamRecycler {
+    public static class Wrapper {
+        private final ByteArrayOutputStreamRecycler recycler;
+        private final ByteArrayOutputStream value;
+
+        public Wrapper(ByteArrayOutputStreamRecycler recycler, ByteArrayOutputStream value) {
+            this.recycler = recycler;
+            this.value = value;
+        }
+
+        public void release() {
+            recycler.release(value);
+        }
+
+        public ByteArrayOutputStream getValue() {
+            return value;
+        }
+    }
+
+    protected final ConcurrentLinkedQueue<ByteArrayOutputStream> buffers;
+
+    public ByteArrayOutputStreamRecycler() {
+        buffers = new ConcurrentLinkedQueue<>();
+    }
+
+    public Wrapper allocOutputStream() {
+        ByteArrayOutputStream result = buffers.poll();
+        if (result == null) {
+            result = new ByteArrayOutputStream();
+        }
+        return new Wrapper(this, result);
+    }
+
+    private void release(ByteArrayOutputStream value) {
+        if (value != null) {
+            value.reset();
+            buffers.offer(value);
+        }
+    }
+}

--- a/core/src/main/java/org/apache/james/mime4j/util/ByteArrayOutputStreamRecycler.java
+++ b/core/src/main/java/org/apache/james/mime4j/util/ByteArrayOutputStreamRecycler.java
@@ -22,13 +22,14 @@ package org.apache.james.mime4j.util;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.apache.commons.io.output.ByteArrayOutputStream;
+import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
 
 public class ByteArrayOutputStreamRecycler {
     public static class Wrapper {
         private final ByteArrayOutputStreamRecycler recycler;
-        private final ByteArrayOutputStream value;
+        private final UnsynchronizedByteArrayOutputStream value;
 
-        public Wrapper(ByteArrayOutputStreamRecycler recycler, ByteArrayOutputStream value) {
+        public Wrapper(ByteArrayOutputStreamRecycler recycler, UnsynchronizedByteArrayOutputStream value) {
             this.recycler = recycler;
             this.value = value;
         }
@@ -37,26 +38,26 @@ public class ByteArrayOutputStreamRecycler {
             recycler.release(value);
         }
 
-        public ByteArrayOutputStream getValue() {
+        public UnsynchronizedByteArrayOutputStream getValue() {
             return value;
         }
     }
 
-    protected final ConcurrentLinkedQueue<ByteArrayOutputStream> buffers;
+    protected final ConcurrentLinkedQueue<UnsynchronizedByteArrayOutputStream> buffers;
 
     public ByteArrayOutputStreamRecycler() {
         buffers = new ConcurrentLinkedQueue<>();
     }
 
     public Wrapper allocOutputStream() {
-        ByteArrayOutputStream result = buffers.poll();
+        UnsynchronizedByteArrayOutputStream result = buffers.poll();
         if (result == null) {
-            result = new ByteArrayOutputStream();
+            result = new UnsynchronizedByteArrayOutputStream();
         }
         return new Wrapper(this, result);
     }
 
-    private void release(ByteArrayOutputStream value) {
+    private void release(UnsynchronizedByteArrayOutputStream value) {
         if (value != null) {
             value.reset();
             buffers.offer(value);

--- a/core/src/main/java/org/apache/james/mime4j/util/ContentUtil.java
+++ b/core/src/main/java/org/apache/james/mime4j/util/ContentUtil.java
@@ -19,7 +19,6 @@
 
 package org.apache.james.mime4j.util;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -31,6 +30,7 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 
+import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.james.mime4j.Charsets;
 
 /**

--- a/core/src/main/java/org/apache/james/mime4j/util/ContentUtil.java
+++ b/core/src/main/java/org/apache/james/mime4j/util/ContentUtil.java
@@ -26,6 +26,7 @@ import java.io.Reader;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
+import java.lang.ref.SoftReference;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
@@ -37,11 +38,24 @@ import org.apache.james.mime4j.Charsets;
  * Utility methods for converting textual content of a message.
  */
 public class ContentUtil {
+    protected static final ThreadLocal<SoftReference<BufferRecycler>> _recyclerRef = new ThreadLocal<>();
+
+    public static BufferRecycler getBufferRecycler() {
+        SoftReference<BufferRecycler> ref = _recyclerRef.get();
+        BufferRecycler br = (ref == null) ? null : ref.get();
+
+        if (br == null) {
+            br = new BufferRecycler();
+            ref = new SoftReference<>(br);
+            _recyclerRef.set(ref);
+        }
+        return br;
+    }
 
     private ContentUtil() {
     }
 
-    static final int DEFAULT_COPY_BUFFER_SIZE = 1024;
+    static final int DEFAULT_COPY_BUFFER_SIZE = 4096;
 
     /**
      * Copies the contents of one stream to the other.
@@ -50,11 +64,13 @@ public class ContentUtil {
      * @throws IOException
      */
     public static void copy(final InputStream in, final OutputStream out) throws IOException {
-        final byte[] buffer = new byte[DEFAULT_COPY_BUFFER_SIZE];
+        BufferRecycler bufferRecycler = getBufferRecycler();
+        byte[] buffer = bufferRecycler.allocByteBuffer(0, DEFAULT_COPY_BUFFER_SIZE);
         int inputLength;
         while (-1 != (inputLength = in.read(buffer))) {
             out.write(buffer, 0, inputLength);
         }
+        bufferRecycler.releaseByteBuffer(0, buffer);
     }
 
     /**
@@ -64,11 +80,13 @@ public class ContentUtil {
      * @throws IOException
      */
     public static void copy(final Reader in, final Writer out) throws IOException {
-        final char[] buffer = new char[DEFAULT_COPY_BUFFER_SIZE];
+        BufferRecycler bufferRecycler = getBufferRecycler();
+        char[] buffer = bufferRecycler.allocCharBuffer(0, DEFAULT_COPY_BUFFER_SIZE);
         int inputLength;
         while (-1 != (inputLength = in.read(buffer))) {
             out.write(buffer, 0, inputLength);
         }
+        bufferRecycler.releaseCharBuffer(0, buffer);
     }
 
     public static byte[] buffer(final InputStream in) throws IOException {

--- a/core/src/main/java/org/apache/james/mime4j/util/ContentUtil.java
+++ b/core/src/main/java/org/apache/james/mime4j/util/ContentUtil.java
@@ -31,7 +31,7 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
+import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
 import org.apache.james.mime4j.Charsets;
 
 /**
@@ -106,7 +106,7 @@ public class ContentUtil {
         if (in == null) {
             throw new IllegalArgumentException("Input stream may not be null");
         }
-        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        UnsynchronizedByteArrayOutputStream buf = new UnsynchronizedByteArrayOutputStream();
         copy(in, buf);
         return buf.toByteArray();
     }

--- a/core/src/main/java/org/apache/james/mime4j/util/ContentUtil.java
+++ b/core/src/main/java/org/apache/james/mime4j/util/ContentUtil.java
@@ -39,6 +39,7 @@ import org.apache.james.mime4j.Charsets;
  */
 public class ContentUtil {
     protected static final ThreadLocal<SoftReference<BufferRecycler>> _recyclerRef = new ThreadLocal<>();
+    protected static final ThreadLocal<SoftReference<ByteArrayOutputStreamRecycler>> _outputStreamRecyclerRef = new ThreadLocal<>();
 
     public static BufferRecycler getBufferRecycler() {
         SoftReference<BufferRecycler> ref = _recyclerRef.get();
@@ -48,6 +49,18 @@ public class ContentUtil {
             br = new BufferRecycler();
             ref = new SoftReference<>(br);
             _recyclerRef.set(ref);
+        }
+        return br;
+    }
+
+    public static ByteArrayOutputStreamRecycler getOutputStreamRecycler() {
+        SoftReference<ByteArrayOutputStreamRecycler> ref = _outputStreamRecyclerRef.get();
+        ByteArrayOutputStreamRecycler br = (ref == null) ? null : ref.get();
+
+        if (br == null) {
+            br = new ByteArrayOutputStreamRecycler();
+            ref = new SoftReference<>(br);
+            _outputStreamRecyclerRef.set(ref);
         }
         return br;
     }
@@ -98,12 +111,12 @@ public class ContentUtil {
         return buf.toByteArray();
     }
 
-    public static ByteArrayOutputStream bufferEfficient(final InputStream in) throws IOException {
+    public static ByteArrayOutputStreamRecycler.Wrapper bufferEfficient(final InputStream in) throws IOException {
         if (in == null) {
             throw new IllegalArgumentException("Input stream may not be null");
         }
-        ByteArrayOutputStream buf = new ByteArrayOutputStream();
-        copy(in, buf);
+        ByteArrayOutputStreamRecycler.Wrapper buf = getOutputStreamRecycler().allocOutputStream();
+        copy(in, buf.getValue());
         return buf;
     }
 

--- a/core/src/main/java/org/apache/james/mime4j/util/ContentUtil.java
+++ b/core/src/main/java/org/apache/james/mime4j/util/ContentUtil.java
@@ -98,6 +98,15 @@ public class ContentUtil {
         return buf.toByteArray();
     }
 
+    public static ByteArrayOutputStream bufferEfficient(final InputStream in) throws IOException {
+        if (in == null) {
+            throw new IllegalArgumentException("Input stream may not be null");
+        }
+        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        copy(in, buf);
+        return buf;
+    }
+
     public static String buffer(final Reader in) throws IOException {
         if (in == null) {
             throw new IllegalArgumentException("Reader may not be null");

--- a/core/src/main/java/org/apache/james/mime4j/util/MimeParameterMapping.java
+++ b/core/src/main/java/org/apache/james/mime4j/util/MimeParameterMapping.java
@@ -28,19 +28,15 @@ public class MimeParameterMapping {
     private final Map<String, String> parameters = new HashMap<>();
 
     public Map<String, String> getParameters() {
-        Map<String,String> result = new HashMap<>();
-        for (Map.Entry<String, String > entry : parameters.entrySet()) {
-            result.put(entry.getKey(), decodeParameterValue(entry.getValue()) );
-        }
-        return result;
+        return parameters;
     }
 
     public void addParameter(String name, String value) {
         String key = removeSectionFromName(name).toLowerCase();
         if (parameters.containsKey(key)) {
-            parameters.put(key, parameters.get(key) + value);
+            parameters.put(key, decodeParameterValue(parameters.get(key) + value));
         } else {
-            parameters.put(key, value);
+            parameters.put(key, decodeParameterValue(value));
         }
     }
 

--- a/core/src/main/java/org/apache/james/mime4j/util/RecycledByteArrayBuffer.java
+++ b/core/src/main/java/org/apache/james/mime4j/util/RecycledByteArrayBuffer.java
@@ -1,0 +1,187 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mime4j.util;
+
+
+/**
+ * A resizable byte array.
+ */
+public final class RecycledByteArrayBuffer implements ByteSequence {
+    private final BufferRecycler bufferRecycler;
+    private byte[] buffer;
+    private int len;
+
+    public RecycledByteArrayBuffer(BufferRecycler bufferRecycler, int capacity) {
+        super();
+        if (capacity < 0) {
+            throw new IllegalArgumentException("Buffer capacity may not be negative");
+        }
+        this.buffer = bufferRecycler.allocByteBuffer(0, capacity);
+        this.bufferRecycler = bufferRecycler;
+    }
+
+    public RecycledByteArrayBuffer(BufferRecycler bufferRecycler, byte[] bytes, boolean dontCopy) {
+        this(bufferRecycler, bytes, bytes.length, dontCopy);
+    }
+
+    public RecycledByteArrayBuffer(BufferRecycler bufferRecycler, byte[] bytes, int len, boolean dontCopy) {
+        if (bytes == null)
+            throw new IllegalArgumentException();
+        if (len < 0 || len > bytes.length)
+            throw new IllegalArgumentException();
+
+        if (dontCopy) {
+            this.buffer = bytes;
+        } else {
+            this.buffer = bufferRecycler.allocByteBuffer(0, len);
+            System.arraycopy(bytes, 0, this.buffer, 0, len);
+        }
+        this.bufferRecycler = bufferRecycler;
+        this.len = len;
+    }
+
+    private void expand(int newlen) {
+        byte newbuffer[] = bufferRecycler.allocByteBuffer(0, Math.max(this.buffer.length << 1, newlen));
+        System.arraycopy(this.buffer, 0, newbuffer, 0, this.len);
+        bufferRecycler.releaseByteBuffer(0, buffer);
+        this.buffer = newbuffer;
+    }
+
+    public void append(final byte[] b, int off, int len) {
+        if (b == null) {
+            return;
+        }
+        if ((off < 0) || (off > b.length) || (len < 0) ||
+                ((off + len) < 0) || ((off + len) > b.length)) {
+            throw new IndexOutOfBoundsException();
+        }
+        if (len == 0) {
+            return;
+        }
+        int newlen = this.len + len;
+        if (newlen > this.buffer.length) {
+            expand(newlen);
+        }
+        System.arraycopy(b, off, this.buffer, this.len, len);
+        this.len = newlen;
+    }
+
+    public void append(int b) {
+        int newlen = this.len + 1;
+        if (newlen > this.buffer.length) {
+            expand(newlen);
+        }
+        this.buffer[this.len] = (byte)b;
+        this.len = newlen;
+    }
+
+    public void clear() {
+        this.len = 0;
+    }
+
+    public byte[] toByteArray() {
+        byte[] b = new byte[this.len];
+        if (this.len > 0) {
+            System.arraycopy(this.buffer, 0, b, 0, this.len);
+        }
+        return b;
+    }
+
+    public byte byteAt(int i) {
+        if (i < 0 || i >= this.len)
+            throw new IndexOutOfBoundsException();
+
+        return this.buffer[i];
+    }
+
+    public int capacity() {
+        return this.buffer.length;
+    }
+
+    public int length() {
+        return this.len;
+    }
+
+    public byte[] buffer() {
+        return this.buffer;
+    }
+
+    public int indexOf(byte b) {
+        return indexOf(b, 0, this.len);
+    }
+
+    public int indexOf(byte b, int beginIndex, int endIndex) {
+        if (beginIndex < 0) {
+            beginIndex = 0;
+        }
+        if (endIndex > this.len) {
+            endIndex = this.len;
+        }
+        if (beginIndex > endIndex) {
+            return -1;
+        }
+        for (int i = beginIndex; i < endIndex; i++) {
+            if (this.buffer[i] == b) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    public void setLength(int len) {
+        if (len < 0 || len > this.buffer.length) {
+            throw new IndexOutOfBoundsException();
+        }
+        this.len = len;
+    }
+
+    public void remove(int off, int len) {
+        if ((off < 0) || (off > this.len) || (len < 0) ||
+                ((off + len) < 0) || ((off + len) > this.len)) {
+            throw new IndexOutOfBoundsException();
+        }
+        if (len == 0) {
+            return;
+        }
+        int remaining = this.len - off - len;
+        if (remaining > 0) {
+            System.arraycopy(this.buffer, off + len, this.buffer, off, remaining);
+        }
+        this.len -= len;
+    }
+
+    public boolean isEmpty() {
+        return this.len == 0;
+    }
+
+    public boolean isFull() {
+        return this.len == this.buffer.length;
+    }
+
+    @Override
+    public String toString() {
+        return new String(toByteArray());
+    }
+
+    public void release() {
+        bufferRecycler.releaseByteBuffer(0, buffer);
+    }
+
+}

--- a/core/src/test/java/org/apache/james/mime4j/stream/DefaultFieldBuilderTest.java
+++ b/core/src/test/java/org/apache/james/mime4j/stream/DefaultFieldBuilderTest.java
@@ -22,6 +22,7 @@ package org.apache.james.mime4j.stream;
 import org.apache.james.mime4j.MimeException;
 import org.apache.james.mime4j.util.ByteArrayBuffer;
 import org.apache.james.mime4j.util.ByteSequence;
+import org.apache.james.mime4j.util.RecycledByteArrayBuffer;
 
 import junit.framework.TestCase;
 
@@ -40,7 +41,7 @@ public class DefaultFieldBuilderTest extends TestCase {
         builder.append(line("raw:   stuff;\r\n"));
         builder.append(line("   more stuff;\r\n"));
         builder.append(line("   a lot more stuff\r\n"));
-        ByteArrayBuffer buf = builder.getRaw();
+        RecycledByteArrayBuffer buf = builder.getRaw();
         assertNotNull(buf);
         assertEquals("raw:   stuff;\r\n   more stuff;\r\n   a lot more stuff\r\n",
                 new String(buf.toByteArray(), "US-ASCII"));
@@ -60,7 +61,7 @@ public class DefaultFieldBuilderTest extends TestCase {
         builder.append(line("raw  : stuff;\r\n"));
         builder.append(line("   more stuff;\r\n"));
         builder.append(line("   a lot more stuff\r\n"));
-        ByteArrayBuffer buf = builder.getRaw();
+        RecycledByteArrayBuffer buf = builder.getRaw();
         assertNotNull(buf);
         assertEquals("raw  : stuff;\r\n   more stuff;\r\n   a lot more stuff\r\n",
                 new String(buf.toByteArray(), "US-ASCII"));
@@ -80,7 +81,7 @@ public class DefaultFieldBuilderTest extends TestCase {
         builder.append(line("raw:   stuff;\r\n"));
         builder.append(line("   more stuff;\r\n"));
         builder.append(line("   a lot more stuff"));
-        ByteArrayBuffer buf = builder.getRaw();
+        RecycledByteArrayBuffer buf = builder.getRaw();
         assertNotNull(buf);
         assertEquals("raw:   stuff;\r\n   more stuff;\r\n   a lot more stuff",
                 new String(buf.toByteArray(), "US-ASCII"));
@@ -109,7 +110,7 @@ public class DefaultFieldBuilderTest extends TestCase {
         DefaultFieldBuilder builder = new DefaultFieldBuilder(0);
         builder.reset();
         builder.append(line("raw: some stuff\r\n"));
-        ByteArrayBuffer buf = builder.getRaw();
+        RecycledByteArrayBuffer buf = builder.getRaw();
         assertNotNull(buf);
         assertEquals("raw: some stuff\r\n", new String(buf.toByteArray(), "US-ASCII"));
         builder.reset();

--- a/dom/pom.xml
+++ b/dom/pom.xml
@@ -63,7 +63,6 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/dom/src/main/java/org/apache/james/mime4j/dom/SingleBody.java
+++ b/dom/src/main/java/org/apache/james/mime4j/dom/SingleBody.java
@@ -23,6 +23,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import org.apache.james.mime4j.util.ContentUtil;
+
 /**
  * Abstract implementation of a single message body; that is, a body that does
  * not contain (directly or indirectly) any other child bodies. It also provides
@@ -76,7 +78,7 @@ public abstract class SingleBody implements Body {
             throw new IllegalArgumentException();
 
         InputStream in = getInputStream();
-        SingleBody.copy(in, out);
+        ContentUtil.copy(in, out);
         in.close();
     }
 
@@ -118,22 +120,6 @@ public abstract class SingleBody implements Body {
      * @see org.apache.james.mime4j.dom.Disposable#dispose()
      */
     public void dispose() {
-    }
-
-    static final int DEFAULT_ENCODING_BUFFER_SIZE = 1024;
-
-    /**
-     * Copies the contents of one stream to the other.
-     * @param in not null
-     * @param out not null
-     * @throws IOException
-     */
-    private static void copy(final InputStream in, final OutputStream out) throws IOException {
-        final byte[] buffer = new byte[DEFAULT_ENCODING_BUFFER_SIZE];
-        int inputLength;
-        while (-1 != (inputLength = in.read(buffer))) {
-            out.write(buffer, 0, inputLength);
-        }
     }
 
 }

--- a/dom/src/main/java/org/apache/james/mime4j/dom/TextBody.java
+++ b/dom/src/main/java/org/apache/james/mime4j/dom/TextBody.java
@@ -21,6 +21,7 @@ package org.apache.james.mime4j.dom;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.nio.charset.Charset;
 
 /**
  * Encapsulates the contents of a <code>text/*</code> entity body.
@@ -39,6 +40,8 @@ public abstract class TextBody extends SingleBody {
      * @return the MIME charset.
      */
     public abstract String getMimeCharset();
+
+    public abstract Charset getCharset();
 
     /**
      * Gets a <code>Reader</code> which may be used to read out the contents

--- a/dom/src/main/java/org/apache/james/mime4j/dom/field/ContentDescriptionField.java
+++ b/dom/src/main/java/org/apache/james/mime4j/dom/field/ContentDescriptionField.java
@@ -21,6 +21,10 @@ package org.apache.james.mime4j.dom.field;
 
 public interface ContentDescriptionField extends ParsedField {
 
+    default boolean bodyDescriptionField() {
+        return true;
+    }
+
     /**
      * Gets the content description defined in this field.
      *

--- a/dom/src/main/java/org/apache/james/mime4j/dom/field/ContentDispositionField.java
+++ b/dom/src/main/java/org/apache/james/mime4j/dom/field/ContentDispositionField.java
@@ -24,6 +24,10 @@ import java.util.Map;
 
 public interface ContentDispositionField extends ParsedField {
 
+    default boolean bodyDescriptionField() {
+        return true;
+    }
+
     /** The <code>inline</code> disposition type. */
     String DISPOSITION_TYPE_INLINE = "inline";
     /** The <code>attachment</code> disposition type. */

--- a/dom/src/main/java/org/apache/james/mime4j/dom/field/ContentIdField.java
+++ b/dom/src/main/java/org/apache/james/mime4j/dom/field/ContentIdField.java
@@ -21,6 +21,10 @@ package org.apache.james.mime4j.dom.field;
 
 public interface ContentIdField extends ParsedField {
 
+    default boolean bodyDescriptionField() {
+        return true;
+    }
+
     /**
      * Gets the content ID defined in this field.
      *

--- a/dom/src/main/java/org/apache/james/mime4j/dom/field/ContentLanguageField.java
+++ b/dom/src/main/java/org/apache/james/mime4j/dom/field/ContentLanguageField.java
@@ -23,6 +23,10 @@ import java.util.List;
 
 public interface ContentLanguageField extends ParsedField {
 
+    default boolean bodyDescriptionField() {
+        return true;
+    }
+
     /**
      * Gets the content language(s) defined in this field.
      *

--- a/dom/src/main/java/org/apache/james/mime4j/dom/field/ContentLengthField.java
+++ b/dom/src/main/java/org/apache/james/mime4j/dom/field/ContentLengthField.java
@@ -21,6 +21,10 @@ package org.apache.james.mime4j.dom.field;
 
 public interface ContentLengthField extends ParsedField {
 
+    default boolean bodyDescriptionField() {
+        return true;
+    }
+
     /**
      * Gets the content length value defined in this field.
      *

--- a/dom/src/main/java/org/apache/james/mime4j/dom/field/ContentLocationField.java
+++ b/dom/src/main/java/org/apache/james/mime4j/dom/field/ContentLocationField.java
@@ -21,6 +21,10 @@ package org.apache.james.mime4j.dom.field;
 
 public interface ContentLocationField extends ParsedField {
 
+    default boolean bodyDescriptionField() {
+        return true;
+    }
+
     /**
      * Gets the content location defined in this field.
      *

--- a/dom/src/main/java/org/apache/james/mime4j/dom/field/ContentMD5Field.java
+++ b/dom/src/main/java/org/apache/james/mime4j/dom/field/ContentMD5Field.java
@@ -21,6 +21,10 @@ package org.apache.james.mime4j.dom.field;
 
 public interface ContentMD5Field extends ParsedField {
 
+    default boolean bodyDescriptionField() {
+        return true;
+    }
+
     /**
      * Gets the content MD5 raw value defined in this field.
      *

--- a/dom/src/main/java/org/apache/james/mime4j/dom/field/ContentTransferEncodingField.java
+++ b/dom/src/main/java/org/apache/james/mime4j/dom/field/ContentTransferEncodingField.java
@@ -21,6 +21,10 @@ package org.apache.james.mime4j.dom.field;
 
 public interface ContentTransferEncodingField extends ParsedField {
 
+    default boolean bodyDescriptionField() {
+        return true;
+    }
+
     /**
      * Gets the encoding defined in this field.
      *

--- a/dom/src/main/java/org/apache/james/mime4j/dom/field/ContentTypeField.java
+++ b/dom/src/main/java/org/apache/james/mime4j/dom/field/ContentTypeField.java
@@ -23,6 +23,10 @@ import java.util.Map;
 
 public interface ContentTypeField extends ParsedField {
 
+    default boolean bodyDescriptionField() {
+        return true;
+    }
+
     /** The prefix of all <code>multipart</code> MIME types. */
     String TYPE_MULTIPART_PREFIX = "multipart/";
     /** The <code>multipart/digest</code> MIME type. */

--- a/dom/src/main/java/org/apache/james/mime4j/dom/field/MimeVersionField.java
+++ b/dom/src/main/java/org/apache/james/mime4j/dom/field/MimeVersionField.java
@@ -21,6 +21,10 @@ package org.apache.james.mime4j.dom.field;
 
 public interface MimeVersionField extends ParsedField {
 
+    default boolean bodyDescriptionField() {
+        return true;
+    }
+
     int getMinorVersion();
 
     int getMajorVersion();

--- a/dom/src/main/java/org/apache/james/mime4j/dom/field/ParsedField.java
+++ b/dom/src/main/java/org/apache/james/mime4j/dom/field/ParsedField.java
@@ -26,6 +26,10 @@ import org.apache.james.mime4j.stream.Field;
  */
 public interface ParsedField extends Field {
 
+    default boolean bodyDescriptionField() {
+        return false;
+    }
+
     /**
      * Returns <code>true</code> if this field is valid, i.e. no errors were
      * encountered while parsing the field value.

--- a/dom/src/main/java/org/apache/james/mime4j/field/Fields.java
+++ b/dom/src/main/java/org/apache/james/mime4j/field/Fields.java
@@ -75,7 +75,7 @@ public class Fields {
      * @return the newly created <i>Content-Type</i> field.
      */
     public static ContentTypeField contentType(String contentType) {
-        return parse(ContentTypeFieldImpl.PARSER, FieldName.CONTENT_TYPE,
+        return parse(ContentTypeFieldLenientImpl.PARSER, FieldName.CONTENT_TYPE,
                 contentType);
     }
 
@@ -97,7 +97,7 @@ public class Fields {
             throw new IllegalArgumentException();
 
         if (parameters == null || parameters.isEmpty()) {
-            return parse(ContentTypeFieldImpl.PARSER, FieldName.CONTENT_TYPE,
+            return parse(ContentTypeFieldLenientImpl.PARSER, FieldName.CONTENT_TYPE,
                     mimeType);
         } else {
             StringBuilder sb = new StringBuilder(mimeType);
@@ -128,7 +128,7 @@ public class Fields {
             throw new IllegalArgumentException(mimeType + " is not a valid MIME type");
         }
         if (parameters == null) {
-            return parse(ContentTypeFieldImpl.PARSER, FieldName.CONTENT_TYPE,
+            return parse(ContentTypeFieldLenientImpl.PARSER, FieldName.CONTENT_TYPE,
                     mimeType);
         } else {
             StringBuilder sb = new StringBuilder(mimeType);
@@ -319,22 +319,22 @@ public class Fields {
             Date creationDate, Date modificationDate, Date readDate) {
         Map<String, String> parameters = new HashMap<String, String>();
         if (filename != null) {
-            parameters.put(ContentDispositionFieldImpl.PARAM_FILENAME, filename);
+            parameters.put(ContentDispositionFieldLenientImpl.PARAM_FILENAME, filename);
         }
         if (size >= 0) {
-            parameters.put(ContentDispositionFieldImpl.PARAM_SIZE, Long
+            parameters.put(ContentDispositionFieldLenientImpl.PARAM_SIZE, Long
                     .toString(size));
         }
         if (creationDate != null) {
-            parameters.put(ContentDispositionFieldImpl.PARAM_CREATION_DATE,
+            parameters.put(ContentDispositionFieldLenientImpl.PARAM_CREATION_DATE,
                     MimeUtil.formatDate(creationDate, null));
         }
         if (modificationDate != null) {
-            parameters.put(ContentDispositionFieldImpl.PARAM_MODIFICATION_DATE,
+            parameters.put(ContentDispositionFieldLenientImpl.PARAM_MODIFICATION_DATE,
                     MimeUtil.formatDate(modificationDate, null));
         }
         if (readDate != null) {
-            parameters.put(ContentDispositionFieldImpl.PARAM_READ_DATE, MimeUtil
+            parameters.put(ContentDispositionFieldLenientImpl.PARAM_READ_DATE, MimeUtil
                     .formatDate(readDate, null));
         }
         return contentDisposition(dispositionType, parameters);
@@ -664,24 +664,24 @@ public class Fields {
     private static DateTimeField date0(String fieldName, Date date,
             TimeZone zone) {
         final String formattedDate = MimeUtil.formatDate(date, zone);
-        return parse(DateTimeFieldImpl.PARSER, fieldName, formattedDate);
+        return parse(DateTimeFieldLenientImpl.PARSER, fieldName, formattedDate);
     }
 
     private static MailboxField mailbox0(String fieldName, Mailbox mailbox) {
         String fieldValue = encodeAddresses(Collections.singleton(mailbox));
-        return parse(MailboxFieldImpl.PARSER, fieldName, fieldValue);
+        return parse(MailboxFieldLenientImpl.PARSER, fieldName, fieldValue);
     }
 
     private static MailboxListField mailboxList0(String fieldName,
             Iterable<Mailbox> mailboxes) {
         String fieldValue = encodeAddresses(mailboxes);
-        return parse(MailboxListFieldImpl.PARSER, fieldName, fieldValue);
+        return parse(MailboxListFieldLenientImpl.PARSER, fieldName, fieldValue);
     }
 
     private static AddressListField addressList0(String fieldName,
             Iterable<? extends Address> addresses) {
         String fieldValue = encodeAddresses(addresses);
-        return parse(AddressListFieldImpl.PARSER, fieldName, fieldValue);
+        return parse(AddressListFieldLenientImpl.PARSER, fieldName, fieldValue);
     }
 
     private static void checkValidFieldName(String fieldName) {

--- a/dom/src/main/java/org/apache/james/mime4j/message/BasicBodyFactory.java
+++ b/dom/src/main/java/org/apache/james/mime4j/message/BasicBodyFactory.java
@@ -35,6 +35,7 @@ import org.apache.james.mime4j.dom.BinaryBody;
 import org.apache.james.mime4j.dom.SingleBody;
 import org.apache.james.mime4j.dom.TextBody;
 import org.apache.james.mime4j.io.InputStreams;
+import org.apache.james.mime4j.util.ByteArrayOutputStreamRecycler;
 import org.apache.james.mime4j.util.ContentUtil;
 
 /**
@@ -223,10 +224,10 @@ public class BasicBodyFactory implements BodyFactory {
 
     static class StringBody3 extends TextBody {
 
-        private final ByteArrayOutputStream content;
+        private final ByteArrayOutputStreamRecycler.Wrapper content;
         private final Charset charset;
 
-        StringBody3(final ByteArrayOutputStream content, final Charset charset) {
+        StringBody3(final ByteArrayOutputStreamRecycler.Wrapper content, final Charset charset) {
             super();
             this.content = content;
             this.charset = charset;
@@ -239,16 +240,17 @@ public class BasicBodyFactory implements BodyFactory {
 
         @Override
         public Reader getReader() throws IOException {
-            return new InputStreamReader(this.content.toInputStream(), this.charset);
+            return new InputStreamReader(this.content.getValue().toInputStream(), this.charset);
         }
 
         @Override
         public InputStream getInputStream() throws IOException {
-            return this.content.toInputStream();
+            return this.content.getValue().toInputStream();
         }
 
         @Override
         public void dispose() {
+            this.content.release();
         }
 
         @Override
@@ -285,20 +287,21 @@ public class BasicBodyFactory implements BodyFactory {
 
     static class BinaryBody3 extends BinaryBody {
 
-        private final ByteArrayOutputStream content;
+        private final ByteArrayOutputStreamRecycler.Wrapper content;
 
-        BinaryBody3(ByteArrayOutputStream content) {
+        BinaryBody3(ByteArrayOutputStreamRecycler.Wrapper content) {
             super();
             this.content = content;
         }
 
         @Override
         public InputStream getInputStream() throws IOException {
-            return content.toInputStream();
+            return content.getValue().toInputStream();
         }
 
         @Override
         public void dispose() {
+            content.release();
         }
 
         @Override

--- a/dom/src/main/java/org/apache/james/mime4j/message/BasicBodyFactory.java
+++ b/dom/src/main/java/org/apache/james/mime4j/message/BasicBodyFactory.java
@@ -22,6 +22,7 @@ package org.apache.james.mime4j.message;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
@@ -221,6 +222,11 @@ public class BasicBodyFactory implements BodyFactory {
         }
 
         @Override
+        public void writeTo(OutputStream out) throws IOException {
+            out.write(content);
+        }
+
+        @Override
         public void dispose() {
         }
 
@@ -263,6 +269,11 @@ public class BasicBodyFactory implements BodyFactory {
         }
 
         @Override
+        public void writeTo(OutputStream out) throws IOException {
+            content.getValue().writeTo(out);
+        }
+
+        @Override
         public void dispose() {
             this.content.release();
         }
@@ -289,6 +300,11 @@ public class BasicBodyFactory implements BodyFactory {
         }
 
         @Override
+        public void writeTo(OutputStream out) throws IOException {
+            out.write(content);
+        }
+
+        @Override
         public void dispose() {
         }
 
@@ -311,6 +327,11 @@ public class BasicBodyFactory implements BodyFactory {
         @Override
         public InputStream getInputStream() throws IOException {
             return content.getValue().toInputStream();
+        }
+
+        @Override
+        public void writeTo(OutputStream out) throws IOException {
+            content.getValue().writeTo(out);
         }
 
         @Override

--- a/dom/src/main/java/org/apache/james/mime4j/message/BasicBodyFactory.java
+++ b/dom/src/main/java/org/apache/james/mime4j/message/BasicBodyFactory.java
@@ -29,7 +29,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.UnsupportedCharsetException;
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.james.mime4j.Charsets;
 import org.apache.james.mime4j.dom.BinaryBody;
 import org.apache.james.mime4j.dom.SingleBody;

--- a/dom/src/main/java/org/apache/james/mime4j/message/BasicBodyFactory.java
+++ b/dom/src/main/java/org/apache/james/mime4j/message/BasicBodyFactory.java
@@ -163,6 +163,11 @@ public class BasicBodyFactory implements BodyFactory {
         }
 
         @Override
+        public Charset getCharset() {
+            return charset;
+        }
+
+        @Override
         public Reader getReader() throws IOException {
             return new StringReader(this.content);
         }
@@ -201,6 +206,11 @@ public class BasicBodyFactory implements BodyFactory {
         }
 
         @Override
+        public Charset getCharset() {
+            return charset;
+        }
+
+        @Override
         public Reader getReader() throws IOException {
             return new InputStreamReader(InputStreams.create(this.content), this.charset);
         }
@@ -235,6 +245,11 @@ public class BasicBodyFactory implements BodyFactory {
         @Override
         public String getMimeCharset() {
             return this.charset != null ? this.charset.name() : null;
+        }
+
+        @Override
+        public Charset getCharset() {
+            return charset;
         }
 
         @Override

--- a/dom/src/main/java/org/apache/james/mime4j/message/DefaultBodyDescriptorBuilder.java
+++ b/dom/src/main/java/org/apache/james/mime4j/message/DefaultBodyDescriptorBuilder.java
@@ -89,7 +89,7 @@ public class DefaultBodyDescriptorBuilder implements BodyDescriptorBuilder {
     public Field addField(final RawField rawfield) throws MimeException {
         ParsedField field = fieldParser.parse(rawfield, monitor);
         String name = field.getNameLowerCase();
-        if (!fields.containsKey(name)) {
+        if (field.bodyDescriptionField() && !fields.containsKey(name)) {
             fields.put(name, field);
         }
         return field;

--- a/dom/src/main/java/org/apache/james/mime4j/message/DefaultMessageBuilder.java
+++ b/dom/src/main/java/org/apache/james/mime4j/message/DefaultMessageBuilder.java
@@ -319,6 +319,7 @@ public class DefaultMessageBuilder implements MessageBuilder {
                 parser.setRecurse();
             }
             parser.parse(is);
+            parser.stop();
             return message;
         } catch (MimeException e) {
             throw new MimeIOException(e);

--- a/dom/src/main/java/org/apache/james/mime4j/message/DefaultMessageWriter.java
+++ b/dom/src/main/java/org/apache/james/mime4j/message/DefaultMessageWriter.java
@@ -40,6 +40,7 @@ import org.apache.james.mime4j.util.ByteArrayBuffer;
 import org.apache.james.mime4j.util.ByteSequence;
 import org.apache.james.mime4j.util.ContentUtil;
 import org.apache.james.mime4j.util.MimeUtil;
+import org.apache.james.mime4j.util.RecycledByteArrayBuffer;
 
 /**
  * Default implementation of {@link MessageWriter}.
@@ -271,6 +272,9 @@ public class DefaultMessageWriter implements MessageWriter {
             throws IOException {
         if (byteSequence instanceof ByteArrayBuffer) {
             ByteArrayBuffer bab = (ByteArrayBuffer) byteSequence;
+            out.write(bab.buffer(), 0, bab.length());
+        } else if (byteSequence instanceof RecycledByteArrayBuffer) {
+            RecycledByteArrayBuffer bab = (RecycledByteArrayBuffer) byteSequence;
             out.write(bab.buffer(), 0, bab.length());
         } else {
             out.write(byteSequence.toByteArray());

--- a/dom/src/main/java/org/apache/james/mime4j/message/SingleBodyBuilder.java
+++ b/dom/src/main/java/org/apache/james/mime4j/message/SingleBodyBuilder.java
@@ -96,16 +96,7 @@ public class SingleBodyBuilder {
             return this;
         }
         if (other instanceof TextBody) {
-            String charsetName = ((TextBody) other).getMimeCharset();
-            if (charsetName != null) {
-                try {
-                    this.charset = Charset.forName(charsetName);
-                } catch (IllegalCharsetNameException ex) {
-                    throw new UnsupportedEncodingException(charsetName);
-                } catch (UnsupportedCharsetException ex) {
-                    throw new UnsupportedEncodingException(charsetName);
-                }
-            }
+            this.charset = ((TextBody) other).getCharset();
         }
         this.bin = ContentUtil.buffer(other.getInputStream());
         return this;

--- a/dom/src/test/java/org/apache/james/mime4j/field/FieldsTest.java
+++ b/dom/src/test/java/org/apache/james/mime4j/field/FieldsTest.java
@@ -100,7 +100,6 @@ public class FieldsTest {
         ContentTypeField field = Fields.contentType("multipart/mixed; "
                 + "boundary=-=Part.0.37877968dd4f6595.11eccf0271c"
                 + ".2dce5678cbc933d5=-");
-        Assert.assertFalse(field.isValidField());
 
         Assert.assertEquals("multipart/mixed", field.getMimeType());
     }

--- a/james-utils/src/main/java/org/apache/james/mime4j/utils/search/MessageMatcher.java
+++ b/james-utils/src/main/java/org/apache/james/mime4j/utils/search/MessageMatcher.java
@@ -199,8 +199,9 @@ public class MessageMatcher {
     }
 
     private boolean checkBody(final CharBuffer buffer, MimeTokenStream parser) throws IOException {
-        final Reader reader = parser.getReader();
-        return isFoundIn(reader, buffer);
+        try (Reader reader = parser.getReader()) {
+            return isFoundIn(reader, buffer);
+        }
     }
 
     private CharBuffer createBuffer(final CharSequence searchContent) {

--- a/storage/src/main/java/org/apache/james/mime4j/storage/StorageTextBody.java
+++ b/storage/src/main/java/org/apache/james/mime4j/storage/StorageTextBody.java
@@ -46,6 +46,11 @@ class StorageTextBody extends TextBody {
     }
 
     @Override
+    public Charset getCharset() {
+        return charset;
+    }
+
+    @Override
     public Reader getReader() throws IOException {
         return new InputStreamReader(storage.getInputStream(), charset);
     }

--- a/storage/src/main/java/org/apache/james/mime4j/storage/StringTextBody.java
+++ b/storage/src/main/java/org/apache/james/mime4j/storage/StringTextBody.java
@@ -50,6 +50,11 @@ class StringTextBody extends TextBody {
     }
 
     @Override
+    public Charset getCharset() {
+        return charset;
+    }
+
+    @Override
     public InputStream getInputStream() throws IOException {
         return new ByteArrayInputStream(text.getBytes(charset.name()));
     }


### PR DESCRIPTION
Running MIME4J-317 benchmarks I realized we were alloction heavy with over 3 GB/s of heap allocation.

MIME4J allocates many large buffer on a very regular basis thus undermining performance.

Looking at what other parsing library does (eg: jackson JSON parsers) buffer recycling is very common.

With MIME4j it significatly decreases allocation rates by a factor 10, unlocking a 37% speedup in the benchmarks.

h3. Consideration

Maybe buffer recycling can be made opt in, enabled via system properties first, and if convincing can be adopted in 0.8.9. Tell me if you want to have a -Dmime4j.buffer.recycling.enabled=true/false system property...

## Benchmarks

```
Benchmark                                                                 Mode  Cnt       Score      Error   Units
JMHLongMultipartReadBench.benchmark1                                      avgt    5      38.040 ±    2.477   us/op
JMHLongMultipartReadBench.benchmark1:·gc.alloc.rate                       avgt    5     429.538 ±   27.742  MB/sec
JMHLongMultipartReadBench.benchmark1:·gc.alloc.rate.norm                  avgt    5   18848.003 ±    0.001    B/op
JMHLongMultipartReadBench.benchmark1:·gc.churn.G1_Eden_Space              avgt    5     422.972 ±   43.836  MB/sec
JMHLongMultipartReadBench.benchmark1:·gc.churn.G1_Eden_Space.norm         avgt    5   18557.822 ±  901.153    B/op
JMHLongMultipartReadBench.benchmark1:·gc.churn.G1_Old_Gen                 avgt    5       0.182 ±    0.001  MB/sec
JMHLongMultipartReadBench.benchmark1:·gc.churn.G1_Old_Gen.norm            avgt    5       7.996 ±    0.514    B/op
JMHLongMultipartReadBench.benchmark1:·gc.count                            avgt    5     206.000             counts
JMHLongMultipartReadBench.benchmark1:·gc.time                             avgt    5     142.000                 ms
JMHLongMultipartReadBench.benchmark2                                      avgt    5      38.440 ±    4.509   us/op
JMHLongMultipartReadBench.benchmark2:·gc.alloc.rate                       avgt    5     426.202 ±   49.068  MB/sec
JMHLongMultipartReadBench.benchmark2:·gc.alloc.rate.norm                  avgt    5   18888.003 ±    0.001    B/op
JMHLongMultipartReadBench.benchmark2:·gc.churn.G1_Eden_Space              avgt    5     421.136 ±   62.518  MB/sec
JMHLongMultipartReadBench.benchmark2:·gc.churn.G1_Eden_Space.norm         avgt    5   18659.616 ±  678.398    B/op
JMHLongMultipartReadBench.benchmark2:·gc.churn.G1_Old_Gen                 avgt    5       0.183 ±    0.003  MB/sec
JMHLongMultipartReadBench.benchmark2:·gc.churn.G1_Old_Gen.norm            avgt    5       8.127 ±    1.023    B/op
JMHLongMultipartReadBench.benchmark2:·gc.count                            avgt    5     204.000             counts
JMHLongMultipartReadBench.benchmark2:·gc.time                             avgt    5     141.000                 ms
JMHLongMultipartReadBench.benchmark3                                      avgt    5      42.973 ±    0.914   us/op
JMHLongMultipartReadBench.benchmark3:·gc.alloc.rate                       avgt    5     489.238 ±   10.389  MB/sec
JMHLongMultipartReadBench.benchmark3:·gc.alloc.rate.norm                  avgt    5   24256.004 ±    0.001    B/op
JMHLongMultipartReadBench.benchmark3:·gc.churn.G1_Eden_Space              avgt    5     484.736 ±   15.802  MB/sec
JMHLongMultipartReadBench.benchmark3:·gc.churn.G1_Eden_Space.norm         avgt    5   24033.264 ±  879.661    B/op
JMHLongMultipartReadBench.benchmark3:·gc.churn.G1_Old_Gen                 avgt    5       0.185 ±    0.005  MB/sec
JMHLongMultipartReadBench.benchmark3:·gc.churn.G1_Old_Gen.norm            avgt    5       9.186 ±    0.083    B/op
JMHLongMultipartReadBench.benchmark3:·gc.count                            avgt    5     208.000             counts
JMHLongMultipartReadBench.benchmark3:·gc.time                             avgt    5     151.000                 ms
JMHLongMultipartReadBench.benchmark4                                      avgt    5      49.676 ±    2.221   us/op
JMHLongMultipartReadBench.benchmark4:·gc.alloc.rate                       avgt    5     477.572 ±   21.207  MB/sec
JMHLongMultipartReadBench.benchmark4:·gc.alloc.rate.norm                  avgt    5   27368.004 ±    0.001    B/op
JMHLongMultipartReadBench.benchmark4:·gc.churn.G1_Eden_Space              avgt    5     471.444 ±   22.344  MB/sec
JMHLongMultipartReadBench.benchmark4:·gc.churn.G1_Eden_Space.norm         avgt    5   27018.820 ± 1483.957    B/op
JMHLongMultipartReadBench.benchmark4:·gc.churn.G1_Old_Gen                 avgt    5       0.196 ±    0.028  MB/sec
JMHLongMultipartReadBench.benchmark4:·gc.churn.G1_Old_Gen.norm            avgt    5      11.233 ±    1.482    B/op
JMHLongMultipartReadBench.benchmark4:·gc.count                            avgt    5     208.000             counts
JMHLongMultipartReadBench.benchmark4:·gc.time                             avgt    5     156.000                 ms
JMHLongMultipartReadBench.benchmark4headers                               avgt    5      64.613 ±    1.900   us/op
JMHLongMultipartReadBench.benchmark4headers:·gc.alloc.rate                avgt    5     846.120 ±   25.011  MB/sec
JMHLongMultipartReadBench.benchmark4headers:·gc.alloc.rate.norm           avgt    5   63072.006 ±    0.001    B/op
JMHLongMultipartReadBench.benchmark4headers:·gc.churn.G1_Eden_Space       avgt    5     835.439 ±   43.786  MB/sec
JMHLongMultipartReadBench.benchmark4headers:·gc.churn.G1_Eden_Space.norm  avgt    5   62274.156 ± 1860.064    B/op
JMHLongMultipartReadBench.benchmark4headers:·gc.churn.G1_Old_Gen          avgt    5       0.233 ±    0.082  MB/sec
JMHLongMultipartReadBench.benchmark4headers:·gc.churn.G1_Old_Gen.norm     avgt    5      17.369 ±    6.178    B/op
JMHLongMultipartReadBench.benchmark4headers:·gc.count                     avgt    5     274.000             counts
JMHLongMultipartReadBench.benchmark4headers:·gc.time                      avgt    5     202.000                 ms
JMHLongMultipartReadBench.benchmark5                                      avgt    5      61.898 ±    3.788   us/op
JMHLongMultipartReadBench.benchmark5:·gc.alloc.rate                       avgt    5    1548.024 ±   96.091  MB/sec
JMHLongMultipartReadBench.benchmark5:·gc.alloc.rate.norm                  avgt    5  110528.005 ±    0.002    B/op
JMHLongMultipartReadBench.benchmark5:·gc.churn.G1_Eden_Space              avgt    5    1537.714 ±   83.535  MB/sec
JMHLongMultipartReadBench.benchmark5:·gc.churn.G1_Eden_Space.norm         avgt    5  109796.006 ± 2474.621    B/op
JMHLongMultipartReadBench.benchmark5:·gc.churn.G1_Old_Gen                 avgt    5       0.322 ±    0.142  MB/sec
JMHLongMultipartReadBench.benchmark5:·gc.churn.G1_Old_Gen.norm            avgt    5      23.005 ±    9.483    B/op
JMHLongMultipartReadBench.benchmark5:·gc.count                            avgt    5     321.000             counts
JMHLongMultipartReadBench.benchmark5:·gc.time                             avgt    5     254.000                 ms
JMHLongMultipartReadBench.benchmark6                                      avgt    5      70.941 ±    3.599   us/op
JMHLongMultipartReadBench.benchmark6:·gc.alloc.rate                       avgt    5     761.682 ±   39.082  MB/sec
JMHLongMultipartReadBench.benchmark6:·gc.alloc.rate.norm                  avgt    5   62333.055 ±  114.253    B/op
JMHLongMultipartReadBench.benchmark6:·gc.churn.G1_Eden_Space              avgt    5     754.006 ±   40.193  MB/sec
JMHLongMultipartReadBench.benchmark6:·gc.churn.G1_Eden_Space.norm         avgt    5   61705.376 ± 1425.790    B/op
JMHLongMultipartReadBench.benchmark6:·gc.churn.G1_Old_Gen                 avgt    5       0.251 ±    0.144  MB/sec
JMHLongMultipartReadBench.benchmark6:·gc.churn.G1_Old_Gen.norm            avgt    5      20.554 ±   11.493    B/op
JMHLongMultipartReadBench.benchmark6:·gc.count                            avgt    5     266.000             counts
JMHLongMultipartReadBench.benchmark6:·gc.time                             avgt    5     200.000                 ms
JMHLongMultipartReadBench.benchmark7                                      avgt    5      31.115 ±    1.657   us/op
JMHLongMultipartReadBench.benchmark7:·gc.alloc.rate                       avgt    5    3402.378 ±  182.781  MB/sec
JMHLongMultipartReadBench.benchmark7:·gc.alloc.rate.norm                  avgt    5  122120.003 ±    0.001    B/op
JMHLongMultipartReadBench.benchmark7:·gc.churn.G1_Eden_Space              avgt    5    3390.947 ±  255.073  MB/sec
JMHLongMultipartReadBench.benchmark7:·gc.churn.G1_Eden_Space.norm         avgt    5  121703.324 ± 3436.756    B/op
JMHLongMultipartReadBench.benchmark7:·gc.churn.G1_Old_Gen                 avgt    5       0.302 ±    0.142  MB/sec
JMHLongMultipartReadBench.benchmark7:·gc.churn.G1_Old_Gen.norm            avgt    5      10.855 ±    5.246    B/op
JMHLongMultipartReadBench.benchmark7:·gc.count                            avgt    5     420.000             counts
JMHLongMultipartReadBench.benchmark7:·gc.time                             avgt    5     433.000                 ms
```

To be compared with results of https://github.com/apache/james-mime4j/pull/73