### PR TITLE
MIME4J-320 Make DateTimeParser case-insensitive for day of week and month

### DIFF
--- a/dom/src/main/javacc/org/apache/james/mime4j/field/datetime/DateTimeParser.jj
+++ b/dom/src/main/javacc/org/apache/james/mime4j/field/datetime/DateTimeParser.jj
@@ -187,7 +187,7 @@ DateTime date_time() :
 String day_of_week() :
 {}
 {
-(    "Mon" | "Tue" | "Wed" | "Thu" | "Fri" | "Sat" | "Sun"
+(    <MON> | <TUE> | <WED> | <THU> | <FRI> | <SAT> | <SUN>
 )
     { return token.image; }
 }
@@ -208,18 +208,18 @@ int day() :
 int month() :
 {}
 {
-    "Jan" { return 1; }
-|   "Feb" { return 2; }
-|   "Mar" { return 3; }
-|   "Apr" { return 4; }
-|   "May" { return 5; }
-|   "Jun" { return 6; }
-|   "Jul" { return 7; }
-|   "Aug" { return 8; }
-|   "Sep" { return 9; }
-|   "Oct" { return 10; }
-|   "Nov" { return 11; }
-|   "Dec" { return 12; }
+    <JAN> { return 1; }
+|   <FEB> { return 2; }
+|   <MAR> { return 3; }
+|   <APR> { return 4; }
+|   <MAY> { return 5; }
+|   <JUN> { return 6; }
+|   <JUL> { return 7; }
+|   <AUG> { return 8; }
+|   <SEP> { return 9; }
+|   <OCT> { return 10; }
+|   <NOV> { return 11; }
+|   <DEC> { return 12; }
 }
 
 String year() :
@@ -344,6 +344,33 @@ MORE :
 TOKEN :
 {
     < DIGITS: ( ["0"-"9"] )+ >
+}
+
+TOKEN [IGNORE_CASE] :
+{
+    < JAN: "Jan" >
+|   < FEB: "Feb" >
+|   < MAR: "Mar" >
+|   < APR: "Apr" >
+|   < MAY: "May" >
+|   < JUN: "Jun" >
+|   < JUL: "Jul" >
+|   < AUG: "Aug" >
+|   < SEP: "Sep" >
+|   < OCT: "Oct" >
+|   < NOV: "Nov" >
+|   < DEC: "Dec" >
+}
+
+TOKEN [IGNORE_CASE] :
+{
+    < MON: "Mon" >
+|   < TUE: "Tue" >
+|   < WED: "Wed" >
+|   < THU: "Thu" >
+|   < FRI: "Fri" >
+|   < SAT: "Sat" >
+|   < SUN: "Sun" >
 }
 
 // GLOBALS

--- a/dom/src/test/java/org/apache/james/mime4j/field/DateTimeTest.java
+++ b/dom/src/test/java/org/apache/james/mime4j/field/DateTimeTest.java
@@ -112,4 +112,34 @@ public class DateTimeTest {
         Assert.assertEquals(1515169108000L, f.getTime());
     }
 
+    @Test
+    public void parseShouldSupportUppercaseDayOfWeek() throws Exception {
+        Date f = parse("WED, 10 Aug 2022 20:00:00 +0200");
+        Assert.assertEquals(1660154400000L, f.getTime());
+    }
+
+    @Test
+    public void parseShouldSupportLowercaseDayOfWeek() throws Exception {
+        Date f = parse("wed, 10 Aug 2022 20:00:00 +0200");
+        Assert.assertEquals(1660154400000L, f.getTime());
+    }
+
+    @Test
+    public void parseShouldSupportUppercaseMonth() throws Exception {
+        Date f = parse("Wed, 10 AUG 2022 20:00:00 +0200");
+        Assert.assertEquals(1660154400000L, f.getTime());
+    }
+
+    @Test
+    public void parseShouldSupportLowercaseMonth() throws Exception {
+        Date f = parse("Wed, 10 aug 2022 20:00:00 +0200");
+        Assert.assertEquals(1660154400000L, f.getTime());
+    }
+
+    @Test
+    public void parseShouldSupportMixedCaseDate() throws Exception {
+        Date f = parse("WeD, 10 aUg 2022 20:00:00 +0200");
+        Assert.assertEquals(1660154400000L, f.getTime());
+    }
+
 }


### PR DESCRIPTION
This changes `DateTimeParser.jj` to ignore case when parsing "day-of-week" and "month".

https://issues.apache.org/jira/browse/MIME4J-320