### PR TITLE
Add version for the javacc-maven-plugin

### DIFF
--- a/dom/pom.xml
+++ b/dom/pom.xml
@@ -72,6 +72,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>javacc-maven-plugin</artifactId>
+                <version>2.6</version>
                 <executions>
                     <execution>
                         <id>generate-jjtree</id>


### PR DESCRIPTION
The javacc-maven-plugin recently got a major upgrade to 3.0.0. The modifications are generating numerous errors in our code that depends on 2.6.

This fixes the build on master that is failing for the above reason