### PR TITLE
MIME4J-321 SingleBody should return its size

### DIFF
--- a/dom/src/main/java/org/apache/james/mime4j/dom/SingleBody.java
+++ b/dom/src/main/java/org/apache/james/mime4j/dom/SingleBody.java
@@ -23,6 +23,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.output.NullOutputStream;
 import org.apache.james.mime4j.util.ContentUtil;
 
 /**
@@ -80,6 +82,10 @@ public abstract class SingleBody implements Body {
         InputStream in = getInputStream();
         ContentUtil.copy(in, out);
         in.close();
+    }
+
+    public long size() throws IOException {
+        return IOUtils.copyLarge(getInputStream(), NullOutputStream.NULL_OUTPUT_STREAM);
     }
 
     /**

--- a/dom/src/main/java/org/apache/james/mime4j/message/BasicBodyFactory.java
+++ b/dom/src/main/java/org/apache/james/mime4j/message/BasicBodyFactory.java
@@ -227,6 +227,11 @@ public class BasicBodyFactory implements BodyFactory {
         }
 
         @Override
+        public long size() {
+            return content.length;
+        }
+
+        @Override
         public void dispose() {
         }
 
@@ -269,6 +274,11 @@ public class BasicBodyFactory implements BodyFactory {
         }
 
         @Override
+        public long size() {
+            return content.getValue().size();
+        }
+
+        @Override
         public void writeTo(OutputStream out) throws IOException {
             content.getValue().writeTo(out);
         }
@@ -305,6 +315,11 @@ public class BasicBodyFactory implements BodyFactory {
         }
 
         @Override
+        public long size() {
+            return content.length;
+        }
+
+        @Override
         public void dispose() {
         }
 
@@ -332,6 +347,11 @@ public class BasicBodyFactory implements BodyFactory {
         @Override
         public void writeTo(OutputStream out) throws IOException {
             content.getValue().writeTo(out);
+        }
+
+        @Override
+        public long size() {
+            return content.getValue().size();
         }
 
         @Override


### PR DESCRIPTION
A quite common need is for instance to get the size off attachments.

Today the DOM API offer no other ways than to read the inputstream of the Body Part and manually compute the size.

However, implementation holding the raw data might already have this value pre-computed and this could be used to get the size very cheaply, without copies.

I propose to add a default "copy" implementation, and provide more optimal implementations where possible.