### PR TITLE
MIME4J-322 Use ArrayDeque in MimeTokenStream

### DIFF
--- a/core/src/main/java/org/apache/james/mime4j/stream/MimeTokenStream.java
+++ b/core/src/main/java/org/apache/james/mime4j/stream/MimeTokenStream.java
@@ -25,7 +25,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
-import java.util.LinkedList;
+import java.util.ArrayDeque;
 
 import org.apache.james.mime4j.Charsets;
 import org.apache.james.mime4j.MimeException;
@@ -82,7 +82,7 @@ public class MimeTokenStream {
     private final DecodeMonitor monitor;
     private final FieldBuilder fieldBuilder;
     private final BodyDescriptorBuilder bodyDescBuilder;
-    private final LinkedList<EntityStateMachine> entities = new LinkedList<EntityStateMachine>();
+    private final ArrayDeque<EntityStateMachine> entities = new ArrayDeque<>();
 
     private EntityState state = EntityState.T_END_OF_STREAM;
     private EntityStateMachine currentStateMachine;


### PR DESCRIPTION
A defacto programming MOJO around is that linked list is bad: overhead of allocating bi-directional pointers, bad cache locality, etc... The benefits are low compared to precised arrays that are a better de-facto choice.

Now see attached a flame graph from James showing 2% of its allocation, and 18.7 of memory allocations of that parsing use case. See attached flame graph.

![Screenshot from 2023-02-13 16-45-40](https://user-images.githubusercontent.com/6928740/218427746-e9c15bab-2a6d-4830-9bce-f6334fde299c.png)


I benchmarked ArrayDeque usage locally and it was shlightly faster (in the ms range) and allocated ~1KB less per message:

```
BEFORE
    JMHLongMultipartReadBench.benchmark1                                      avgt    5      39.842 ±    1.820   us/op
    JMHLongMultipartReadBench.benchmark1:·gc.alloc.rate.norm                  avgt    5   19448.003 ±    0.001    B/op

AFTER
    JMHLongMultipartReadBench.benchmark1                               avgt    5     38.687 ±   2.935   us/op
    JMHLongMultipartReadBench.benchmark1:·gc.alloc.rate.norm           avgt    5  18128.003 ±   0.001    B/op
```


