### PR TITLE
Multipart utf-8 filename

### DIFF
--- a/core/src/main/java/org/apache/james/mime4j/util/MimeParameterMapping.java
+++ b/core/src/main/java/org/apache/james/mime4j/util/MimeParameterMapping.java
@@ -25,6 +25,8 @@ import java.util.Map;
 public class MimeParameterMapping {
 
     private final Map<String, String> parameters = new HashMap<>();
+    /** Charset, taken from the first item added to {@link #parameters}. */
+    private String charset;
 
     public Map<String, String> getParameters() {
         return parameters;
@@ -50,15 +52,23 @@ public class MimeParameterMapping {
         int charsetEnd = value.indexOf("'");
         int languageEnd = value.indexOf("'", charsetEnd + 1);
         if (charsetEnd < 0 || languageEnd < 0) {
-            return MimeUtil.unscrambleHeaderValue(value);
+            if (charset != null) {
+                return urlDecode(value);
+            } else {
+                return MimeUtil.unscrambleHeaderValue(value);
+            }
         }
-        String charset = value.substring(0, charsetEnd);
+        charset = value.substring(0, charsetEnd);
         String fileName = value.substring(languageEnd + 1);
+        return urlDecode(fileName);
+    }
+
+    private String urlDecode(String value) {
         try {
-            return java.net.URLDecoder.decode(fileName, charset);
+            return java.net.URLDecoder.decode(value, charset);
         }
         catch (Exception ignore) {
-            return fileName;
+            return value;
         }
     }
 

--- a/dom/src/test/java/org/apache/james/mime4j/field/LenientContentDispositionFieldTest.java
+++ b/dom/src/test/java/org/apache/james/mime4j/field/LenientContentDispositionFieldTest.java
@@ -124,7 +124,7 @@ public class LenientContentDispositionFieldTest {
             " FileName=\"=?WINDOWS-1251?Q?3244659=5F=C0=EA=F2_=E7=E0_=C8=FE=EB=FC_?=\n" +
             " =?WINDOWS-1251?Q?2020.pdf?=\"")
             .getBytes(StandardCharsets.UTF_8);
-        
+
         ContentDispositionField f = parse(data);
 
         Assert.assertEquals("WINDOWS-1251 Q encoded filename", "3244659_Акт за Июль 2020.pdf", f.getFilename());
@@ -132,13 +132,24 @@ public class LenientContentDispositionFieldTest {
 
     @Test
     public void testGetFilenameUtf8() throws Exception {
-        byte[] data = 
+        byte[] data =
             "Content-Disposition: attachment; filename=\"УПД ОБЩЕСТВО С ОГРАНИЧЕННОЙ ОТВЕТСТВЕННОСТЬЮ \"СТАНЦИЯ ВИРТУАЛЬНАЯ\" 01-05-21.pdf\""
             .getBytes(StandardCharsets.UTF_8);
 
         ContentDispositionField f = parse(data);
 
         Assert.assertEquals("UTF8 encoded filename", "УПД ОБЩЕСТВО С ОГРАНИЧЕННОЙ ОТВЕТСТВЕННОСТЬЮ \"СТАНЦИЯ ВИРТУАЛЬНАЯ\" 01-05-21.pdf", f.getFilename());
+    }
+
+    @Test
+    public void testGetFilenameMultipartUtf8() throws Exception {
+        byte[] data = ("Content-Disposition: attachment;\n" +
+            "	filename*0*=\"UTF-8''%D0%A0%D0%BE%D1%81%D1%82%D0%B5%D0%BB%D0%B5%D0%BA%D0%BE\";\n" +
+            "	filename*1*=\"%D0%BC%2E%78%6C%73%78\"\n")
+            .getBytes(StandardCharsets.UTF_8);
+
+        ContentDispositionField f = parse(data);
+        Assert.assertEquals("Ростелеком.xlsx", f.getFilename());
     }
 
     @Test


### PR DESCRIPTION
Multipart UTF-8 attachment filenames weren't properly decoded. Please, see a sample in the extended test. 