### PR TITLE
MIME4J-197 Fixup case Mailbox parser absent domain part

### DIFF
--- a/dom/src/main/java/org/apache/james/mime4j/field/address/LenientAddressParser.java
+++ b/dom/src/main/java/org/apache/james/mime4j/field/address/LenientAddressParser.java
@@ -152,7 +152,7 @@ public class LenientAddressParser implements AddressParser {
         }
         pos = cursor.getPos();
         current = (char) (buf.byteAt(pos) & 0xff);
-        if (current == AT) {
+        if (current == AT || current == CLOSING_BRACKET) {
             cursor.updatePos(pos + 1);
         } else {
             return createMailbox(openingText, domainList, localPart, null);

--- a/dom/src/test/java/org/apache/james/mime4j/field/FieldsTest.java
+++ b/dom/src/test/java/org/apache/james/mime4j/field/FieldsTest.java
@@ -21,6 +21,7 @@ package org.apache.james.mime4j.field;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -397,6 +398,14 @@ public class FieldsTest {
         Assert.assertEquals("Resent-To: The Does: JD <john.doe@acme.org>, "
                 + "jane.doe@example.org;, Mary\r\n Smith <mary@example.net>",
                 decode(field));
+    }
+
+    @Test
+    public void testAddressListWhenMailboxAbsentDomain() {
+        Mailbox mailbox = new Mailbox("name1", "localpart", "");
+        AddressListField field = Fields.addressList("To", Collections.singleton(mailbox));
+        Assert.assertEquals(1, field.getAddressList().size());
+        Assert.assertEquals(mailbox, field.getAddressList().get(0));
     }
 
     @Test


### PR DESCRIPTION

When parsing the rawField `To: name1 <invalid1>` 
by [AddressListFieldLenientImpl](https://github.com/apache/james-mime4j/blob/8a109f0ccdffebe6f15b3e29483a5e22b401e6dc/dom/src/main/java/org/apache/james/mime4j/field/AddressListFieldLenientImpl.java#L39)
The AddressList return incorrect

Actual: size 2 (`invalid`, `>`)

Expected: size 1 (`invalid`)

![image](https://github.com/linagora/james-project/assets/81145350/43c1bca4-f63f-48fe-9018-b964879cd6f9)




