### PR TITLE
MIME4J-330 Fix MimeStreamParser bug: part body stream ends with CR

### DIFF
--- a/core/src/main/java/org/apache/james/mime4j/io/MimeBoundaryInputStream.java
+++ b/core/src/main/java/org/apache/james/mime4j/io/MimeBoundaryInputStream.java
@@ -245,14 +245,14 @@ public class MimeBoundaryInputStream extends LineReaderInputStream {
                     // Make sure the boundary is terminated with EOS
                     break;
                 } else {
-                    // or with a whitespace or '--' 
+                    // or with a whitespace or '--'
                     char ch = (char)(buffer.byteAt(pos));
                     if (CharsetUtil.isWhitespace(ch)) {
                         break;
                     }
                     if (ch == '-' && remaining > 1 && (char)(buffer.byteAt(pos+1)) == '-') {
                         break;
-                    } 
+                    }
                 }
             }
             off = i + boundary.length;
@@ -265,8 +265,14 @@ public class MimeBoundaryInputStream extends LineReaderInputStream {
             if (eof) {
                 limit = buffer.limit();
             } else {
-                limit = buffer.limit() - (boundary.length + 2);
-                                // [LF] [boundary] [CR][LF] minus one char
+                int position = buffer.limit() - (boundary.length + 3);    // 2nd position before boundary
+                if (position >= 0 && (char) buffer.byteAt(position) == '\r') {
+                    limit = buffer.limit() - (boundary.length + 3);
+                    // boundary [CR][LF] minus two chars
+                } else {
+                    limit = buffer.limit() - (boundary.length + 2);
+                    // boundary [LF] minus one char
+                }
             }
         }
         return bytesRead;

--- a/core/src/test/java/org/apache/james/mime4j/parser/ExtractPartWithDifferentLengthsTest.java
+++ b/core/src/test/java/org/apache/james/mime4j/parser/ExtractPartWithDifferentLengthsTest.java
@@ -1,0 +1,73 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mime4j.parser;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.james.mime4j.MimeException;
+import org.apache.james.mime4j.stream.BodyDescriptor;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+public class ExtractPartWithDifferentLengthsTest {
+    @Test
+    public void testExtractPartWithDifferentLengths() throws Exception {
+        StringBuilder partBuilder = new StringBuilder();
+        for (int i = 1; i <= 5000; i++) {
+            partBuilder.append(i % 80 == 0 ? "\n" : "A");
+            String part = partBuilder.toString();
+            String mimeMessage = createMimeMultipart(part);
+
+            String extracted = extractPart(mimeMessage);
+            Assert.assertEquals(part, extracted);
+        }
+    }
+
+    private String createMimeMultipart(String part) {
+        return "Content-type: multipart/mixed; boundary=QvEgqhjEnYxz\n"
+            + "\n"
+            + "--QvEgqhjEnYxz\n"
+            + "Content-Type: text/plain\n"
+            + "\n"
+            + part
+            + "\r\n"
+            + "--QvEgqhjEnYxz--\n";
+    }
+
+    private String extractPart(String mimeMessage) throws
+        MimeException, IOException {
+        String[] resultWrapper = new String[1];
+
+        MimeStreamParser parser = new MimeStreamParser();
+        parser.setContentHandler(new AbstractContentHandler() {
+            @Override
+            public void body(BodyDescriptor bd, InputStream is) throws IOException {
+                resultWrapper[0] = new String(IOUtils.toString(is,
+                    StandardCharsets.UTF_8).getBytes());
+            }
+        });
+        parser.parse(new ByteArrayInputStream(mimeMessage.getBytes()));
+        return resultWrapper[0];
+    }
+}


### PR DESCRIPTION
Root cause:

In ExtractPartWithDifferentLengthsTest:
```
        for (int i = 1; i <= 5000; i++) {
            partBuilder.append(i % 80 == 0 ? "\n" : "A");
```

 when the content part input reaches a specific length, due to the limit of the buffer in MimeBoundaryInputStream, the parser extract the content part with '\r' at the end (without '\n').
```
            + "--QvEgqhjEnYxz\n"
            + "Content-Type: text/plain\n"
            + "\n"
            + part
            + "\r\n"
            + "--QvEgqhjEnYxz--\n";
```

It seems in mime4j, '\r' without '\n' is still considered as a new line. Therefore, a new empty line is added at the end of content part.