### PR TITLE
Add support for RFC 6532, and test it.

### DIFF
--- a/core/src/main/java/org/apache/james/mime4j/stream/RawFieldParser.java
+++ b/core/src/main/java/org/apache/james/mime4j/stream/RawFieldParser.java
@@ -323,6 +323,7 @@ public class RawFieldParser {
      */
     public void copyContent(final ByteSequence buf, final ParserCursor cursor, final BitSet delimiters,
             final StringBuilder dst) {
+        ByteArrayBuffer dstRaw = new ByteArrayBuffer(80);
         int pos = cursor.getPos();
         int indexFrom = cursor.getPos();
         int indexTo = cursor.getUpperBound();
@@ -333,10 +334,11 @@ public class RawFieldParser {
                 break;
             } else {
                 pos++;
-                dst.append(current);
+                dstRaw.append(current);
             }
         }
         cursor.updatePos(pos);
+        dst.append(ContentUtil.decode(StandardCharsets.UTF_8, dstRaw));
     }
 
     /**

--- a/core/src/test/java/org/apache/james/mime4j/parser/MimeStreamParserTest.java
+++ b/core/src/test/java/org/apache/james/mime4j/parser/MimeStreamParserTest.java
@@ -439,7 +439,7 @@ public class MimeStreamParserTest {
         TestHandler handler = new TestHandler();
         parser.setContentHandler(handler);
 
-        String msg = "Subject: Naive Subject\r\n"
+        String msg = "Subject: Naïve Subject\r\n"
                 + "From: foo@ø.example\r\n"
                 + "To: ø@example.com\r\n"
                 + "Content-Type: text/plain; charset=utf-8\r\n"
@@ -448,7 +448,7 @@ public class MimeStreamParserTest {
         String expected = "<message>\r\n"
                 + "<header>\r\n"
                 + "<field>\r\n"
-                + "Subject: Naive Subject"
+                + "Subject: Naïve Subject"
                 + "</field>\r\n"
                 + "<field>\r\n"
                 + "From: foo@ø.example"

--- a/core/src/test/java/org/apache/james/mime4j/parser/TestHandler.java
+++ b/core/src/test/java/org/apache/james/mime4j/parser/TestHandler.java
@@ -22,6 +22,7 @@ package org.apache.james.mime4j.parser;
 import java.io.IOException;
 import java.io.InputStream;
 
+import org.apache.james.mime4j.Charsets;
 import org.apache.james.mime4j.parser.ContentHandler;
 import org.apache.james.mime4j.stream.BodyDescriptor;
 import org.apache.james.mime4j.stream.Field;
@@ -94,7 +95,7 @@ class TestHandler implements ContentHandler {
         sb.append("<header>\r\n");
     }
     public void field(Field field) {
-        sb.append("<field>\r\n").append(escape(ContentUtil.decode(field.getRaw()))).append("</field>\r\n");
+        sb.append("<field>\r\n").append(escape(ContentUtil.decode(Charsets.UTF_8, field.getRaw()))).append("</field>\r\n");
     }
     public void endHeader() {
         sb.append("</header>\r\n");

--- a/core/src/test/java/org/apache/james/mime4j/stream/RawFieldParserTest.java
+++ b/core/src/test/java/org/apache/james/mime4j/stream/RawFieldParserTest.java
@@ -248,6 +248,17 @@ public class RawFieldParserTest {
     }
 
     @Test
+    public void testLongString() throws Exception {
+        String body = "01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890";
+        String s = "raw: " + body;
+        ByteSequence raw = ContentUtil.encode(s);
+
+        RawField rawField = parser.parseField(raw);
+        Assert.assertEquals("raw", rawField.getName());
+        Assert.assertEquals(body, rawField.getBody());
+    }
+
+    @Test
     public void testParsingInvalidSyntax2() throws Exception {
         String s = "raw    \t \t";
         ByteSequence raw = ContentUtil.encode(s);

--- a/core/src/test/java/org/apache/james/mime4j/stream/RawFieldParserTest.java
+++ b/core/src/test/java/org/apache/james/mime4j/stream/RawFieldParserTest.java
@@ -75,6 +75,25 @@ public class RawFieldParserTest {
         Assert.assertTrue(cursor.atEnd());
     }
 
+
+    @Test
+    public void testUtf8StringParsing() throws Exception {
+        String s = "grå \"rød\"";
+        ByteSequence raw = ContentUtil.encode(s);
+        ParserCursor cursor = new ParserCursor(0, 2 + s.length());
+
+        StringBuilder strbuf1 = new StringBuilder();
+        parser.copyContent(raw, cursor, RawFieldParser.INIT_BITSET(':'), strbuf1);
+        Assert.assertFalse(cursor.atEnd());
+        Assert.assertEquals("grå", strbuf1.toString());
+
+        parser.skipWhiteSpace(raw, cursor);
+
+        StringBuilder strbuf2 = new StringBuilder();
+        parser.copyQuotedContent(raw, cursor, strbuf2);
+        Assert.assertEquals("rød", strbuf2.toString());
+    }
+
     @Test
     public void testTokenParsingWithQuotedPairs() throws Exception {
         String s = "raw: \"\\\"some\\stuff\\\\\"";

--- a/core/src/test/java/org/apache/james/mime4j/stream/RawFieldTest.java
+++ b/core/src/test/java/org/apache/james/mime4j/stream/RawFieldTest.java
@@ -38,6 +38,9 @@ public class RawFieldTest {
         Assert.assertEquals("raw", field.getName());
         Assert.assertEquals("stuff;  more stuff", field.getBody());
         Assert.assertEquals(s, field.toString());
+        raw = ContentUtil.encode("To: ø@ø.example");
+        field = new RawField(raw, 3, "To", null);
+        Assert.assertEquals("ø@ø.example", field.getBody());
     }
 
     @Test

--- a/dom/src/main/java/org/apache/james/mime4j/field/address/LenientAddressParser.java
+++ b/dom/src/main/java/org/apache/james/mime4j/field/address/LenientAddressParser.java
@@ -217,7 +217,7 @@ public class LenientAddressParser implements AddressParser {
 
     public Mailbox parseMailbox(final CharSequence text) {
         ByteSequence raw = ContentUtil.encode(text);
-        ParserCursor cursor = new ParserCursor(0, text.length());
+        ParserCursor cursor = new ParserCursor(0, raw.length());
         return parseMailbox(raw, cursor, null);
     }
 

--- a/dom/src/main/jjtree/org/apache/james/mime4j/field/address/AddressListParser.jjt
+++ b/dom/src/main/jjtree/org/apache/james/mime4j/field/address/AddressListParser.jjt
@@ -243,7 +243,9 @@ TOKEN :
 {
 	< #ALPHA: ["a" - "z", "A" - "Z"] >
 |	< #DIGIT: ["0" - "9"] >
+|	< UTF8NONASCII: ["\u0080" - "\uFFFF"] >
 |	< #ATEXT: ( <ALPHA> | <DIGIT>
+			  | <UTF8NONASCII>
 			  | "!" | "#" | "$" | "%"
 			  | "&" | "'" | "*" | "+"
 			  | "-" | "/" | "=" | "?"

--- a/dom/src/test/java/org/apache/james/mime4j/field/address/DefaultAddressBuilderTest.java
+++ b/dom/src/test/java/org/apache/james/mime4j/field/address/DefaultAddressBuilderTest.java
@@ -67,6 +67,10 @@ public class DefaultAddressBuilderTest {
         Assert.assertEquals("Hans M\374ller", mailbox5.getName());
         Assert.assertEquals("hans.mueller@acme.org", mailbox5.getAddress());
 
+        // UTF8 should be allowed in atoms too now
+        Mailbox mailbox6 = parser.parseMailbox(
+                "<dr.müller@dr-müller-lüdenscheid.de>");
+        Assert.assertEquals("dr.müller@dr-müller-lüdenscheid.de", mailbox6.getAddress());
     }
 
     @Test

--- a/dom/src/test/java/org/apache/james/mime4j/field/address/LenientAddressBuilderTest.java
+++ b/dom/src/test/java/org/apache/james/mime4j/field/address/LenientAddressBuilderTest.java
@@ -231,6 +231,11 @@ public class LenientAddressBuilderTest {
                 "\"Hans M\374ller\" <hans.mueller@acme.org>");
         Assert.assertEquals("Hans M\374ller", mailbox5.getName());
         Assert.assertEquals("hans.mueller@acme.org", mailbox5.getAddress());
+
+        // UTF8 should be allowed in atoms too now
+        Mailbox mailbox6 = parser.parseMailbox(
+                "<dr.müller@dr-müller-lüdenscheid.de>");
+        Assert.assertEquals("dr.müller@dr-müller-lüdenscheid.de", mailbox6.getAddress());
     }
 
     @Test


### PR DESCRIPTION
Not much to do here — code written in Java can hardly avoid having good support for unicode strings.
 - The syntax for an atom has been extended. 
 - Two places silently assumed that he length of a string in bytes is the same as its length in characters.
 - Tests.

James now assumes that if "8-bit" header field values aren't otherwise labelled, then they are UTF8. That was _mostly_ the case before, now it's _always_ the case AFAICT.