### PR TITLE
MIME4J-333 Introducing a getSafeRaw() method in RawField

### DIFF
--- a/core/src/main/java/org/apache/james/mime4j/stream/Field.java
+++ b/core/src/main/java/org/apache/james/mime4j/stream/Field.java
@@ -61,4 +61,9 @@ public interface Field {
      */
     ByteSequence getRaw();
 
+    /**
+     * Gets original (raw) representation of the field, if available,
+     * or compute it lazily otherwise.
+     */
+    ByteSequence getSafeRaw();
 }

--- a/core/src/main/java/org/apache/james/mime4j/stream/RawField.java
+++ b/core/src/main/java/org/apache/james/mime4j/stream/RawField.java
@@ -85,6 +85,24 @@ public final class RawField implements Field {
         return raw;
     }
 
+    /**
+     * Gets original (raw) representation of the field, if available,
+     * or compute it lazily otherwise.
+     */
+    public ByteSequence getSafeRaw() {
+        if (raw == null) {
+            StringBuilder buf = new StringBuilder();
+            buf.append(getName());
+            buf.append(": ");
+            String body = getBody();
+            if (body != null) {
+                buf.append(body);
+            }
+            return ContentUtil.encode(MimeUtil.fold(buf.toString(), 0));
+        }
+        return raw;
+    }
+
     public String getName() {
         return name;
     }

--- a/core/src/test/java/org/apache/james/mime4j/stream/RawFieldTest.java
+++ b/core/src/test/java/org/apache/james/mime4j/stream/RawFieldTest.java
@@ -22,10 +22,11 @@ package org.apache.james.mime4j.stream;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
-import junit.framework.Assert;
 import org.apache.james.mime4j.util.ByteSequence;
 import org.apache.james.mime4j.util.ContentUtil;
 import org.junit.Test;
+
+import junit.framework.Assert;
 
 public class RawFieldTest {
 
@@ -35,6 +36,7 @@ public class RawFieldTest {
         ByteSequence raw = ContentUtil.encode(s);
         RawField field = new RawField(raw, 3, "raw", null);
         Assert.assertSame(raw, field.getRaw());
+        Assert.assertSame(raw, field.getSafeRaw());
         Assert.assertEquals("raw", field.getName());
         Assert.assertEquals("stuff;  more stuff", field.getBody());
         Assert.assertEquals(s, field.toString());
@@ -47,12 +49,14 @@ public class RawFieldTest {
     public void testPublicConstructor() throws Exception {
         RawField field1 = new RawField("raw", "stuff");
         Assert.assertNull(field1.getRaw());
+        Assert.assertEquals("raw: stuff", ContentUtil.decode(field1.getSafeRaw()));
         Assert.assertEquals("raw", field1.getName());
         Assert.assertEquals("stuff", field1.getBody());
         Assert.assertEquals("raw: stuff", field1.toString());
 
         RawField field2 = new RawField("raw", "any");
         Assert.assertNull(field2.getRaw());
+        Assert.assertEquals("raw: any", ContentUtil.decode(field2.getSafeRaw()));
         Assert.assertEquals("raw", field2.getName());
         Assert.assertEquals("any", field2.getBody());
         Assert.assertEquals("raw: any", field2.toString());
@@ -64,6 +68,7 @@ public class RawFieldTest {
         ByteSequence raw = ContentUtil.encode(s);
         RawField field = new RawField(raw, 3, "raw", null);
         Assert.assertSame(raw, field.getRaw());
+        Assert.assertSame(raw, field.getSafeRaw());
         Assert.assertEquals("raw", field.getName());
         Assert.assertEquals("stuff;  more stuff", field.getBody());
         Assert.assertEquals(s, field.toString());

--- a/dom/src/main/java/org/apache/james/mime4j/field/AbstractField.java
+++ b/dom/src/main/java/org/apache/james/mime4j/field/AbstractField.java
@@ -80,6 +80,14 @@ public abstract class AbstractField implements ParsedField {
     }
 
     /**
+     * Gets original (raw) representation of the field, if available,
+     * or compute it lazily otherwise.
+     */
+    public ByteSequence getSafeRaw() {
+        return rawField.getSafeRaw();
+    }
+
+    /**
      * @see ParsedField#isValidField()
      */
     public boolean isValidField() {

--- a/dom/src/main/java/org/apache/james/mime4j/message/DefaultMessageWriter.java
+++ b/dom/src/main/java/org/apache/james/mime4j/message/DefaultMessageWriter.java
@@ -194,17 +194,7 @@ public class DefaultMessageWriter implements MessageWriter {
      *             if an I/O error occurs.
      */
     public void writeField(Field field, OutputStream out) throws IOException {
-        ByteSequence raw = field.getRaw();
-        if (raw == null) {
-            StringBuilder buf = new StringBuilder();
-            buf.append(field.getName());
-            buf.append(": ");
-            String body = field.getBody();
-            if (body != null) {
-                buf.append(body);
-            }
-            raw = ContentUtil.encode(MimeUtil.fold(buf.toString(), 0));
-        }
+        ByteSequence raw = field.getSafeRaw();
         writeBytes(raw, out);
         out.write(CRLF);
     }


### PR DESCRIPTION
That would allow projects using the mime4j library to be able to get a raw field without it returning a null value, to protect against potential NPE, without introducing breaking changes with its core API.

The computing of the raw value in case it's null is based on what was in writeField method in DefaultMessageWriter.