### PR TITLE
[FIX] Limit multipart count and nesting and other parsing improvments

### DIFF
--- a/core/src/main/java/org/apache/james/mime4j/io/MaxNestingDepthLimitException.java
+++ b/core/src/main/java/org/apache/james/mime4j/io/MaxNestingDepthLimitException.java
@@ -1,0 +1,38 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mime4j.io;
+
+import org.apache.james.mime4j.MimeException;
+
+/**
+ * Signals a parsing error due to MIME entities (multiparts and embedded
+ * messages) being nested more deeply than the maximum limit.
+ *
+ * @see org.apache.james.mime4j.stream.MimeConfig.Builder#setMaxNestingDepth(int)
+ */
+public class MaxNestingDepthLimitException extends MimeException {
+
+    private static final long serialVersionUID = 6011628067570972836L;
+
+    public MaxNestingDepthLimitException(final String message) {
+        super(message);
+    }
+
+}

--- a/core/src/main/java/org/apache/james/mime4j/io/MaxPartCountLimitException.java
+++ b/core/src/main/java/org/apache/james/mime4j/io/MaxPartCountLimitException.java
@@ -1,0 +1,38 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mime4j.io;
+
+import org.apache.james.mime4j.MimeException;
+
+/**
+ * Signals a parsing error due to the total number of MIME entities (body parts
+ * and embedded messages) contained in a message exceeding the maximum limit.
+ *
+ * @see org.apache.james.mime4j.stream.MimeConfig.Builder#setMaxPartCount(int)
+ */
+public class MaxPartCountLimitException extends MimeException {
+
+    private static final long serialVersionUID = -7742064603843344870L;
+
+    public MaxPartCountLimitException(final String message) {
+        super(message);
+    }
+
+}

--- a/core/src/main/java/org/apache/james/mime4j/stream/MimeConfig.java
+++ b/core/src/main/java/org/apache/james/mime4j/stream/MimeConfig.java
@@ -28,7 +28,7 @@ public final class MimeConfig {
 
     public static final MimeConfig PERMISSIVE = MimeConfig.custom()
         .setMaxContentLen(100 * 1024 * 1024)
-        .setMaxHeaderCount(-1)
+        .setMaxHeaderCount(4096)
         .setMaxHeaderLen(-1)
         .setMaxLineLen(-1)
         .build();
@@ -43,6 +43,7 @@ public final class MimeConfig {
     private final int maxHeaderCount;
     private final int maxHeaderLen;
     private final long maxContentLen;
+    private final int maxTotalHeaderCount;
     private final int maxPartCount;
     private final int maxNestingDepth;
     private final boolean countLineNumbers;
@@ -55,6 +56,7 @@ public final class MimeConfig {
             int maxHeaderCount,
             int maxHeaderLen,
             long maxContentLen,
+            int maxTotalHeaderCount,
             int maxPartCount,
             int maxNestingDepth,
             boolean countLineNumbers,
@@ -67,6 +69,7 @@ public final class MimeConfig {
         this.maxHeaderCount = maxHeaderCount;
         this.maxHeaderLen = maxHeaderLen;
         this.maxContentLen = maxContentLen;
+        this.maxTotalHeaderCount = maxTotalHeaderCount;
         this.maxPartCount = maxPartCount;
         this.maxNestingDepth = maxNestingDepth;
         this.headlessParsing = headlessParsing;
@@ -138,6 +141,17 @@ public final class MimeConfig {
     }
 
     /**
+     * Returns the maximum total header count limit
+     *
+     * @see Builder#setMaxTotalHeaderCount(int)
+     *
+     * @return value of the maximum total header count limit
+     */
+    public int getMaxTotalHeaderCount() {
+        return maxTotalHeaderCount;
+    }
+
+    /**
      * Returns the maximum part count limit
      *
      * @see Builder#setMaxPartCount(int)
@@ -187,6 +201,7 @@ public final class MimeConfig {
                 .append(", maxHeaderCount=").append(maxHeaderCount)
                 .append(", maxHeaderLen=").append(maxHeaderLen)
                 .append(", maxContentLen=").append(maxContentLen)
+                .append(", maxTotalHeaderCount=").append(maxTotalHeaderCount)
                 .append(", maxPartCount=").append(maxPartCount)
                 .append(", maxNestingDepth=").append(maxNestingDepth)
                 .append(", countLineNumbers=").append(countLineNumbers)
@@ -210,6 +225,7 @@ public final class MimeConfig {
             .setMaxHeaderCount(config.getMaxHeaderCount())
             .setMaxHeaderLen(config.getMaxHeaderLen())
             .setMaxContentLen(config.getMaxContentLen())
+            .setMaxTotalHeaderCount(config.getMaxTotalHeaderCount())
             .setMaxPartCount(config.getMaxPartCount())
             .setMaxNestingDepth(config.getMaxNestingDepth())
             .setCountLineNumbers(config.isCountLineNumbers())
@@ -224,6 +240,7 @@ public final class MimeConfig {
         private int maxHeaderCount;
         private int maxHeaderLen;
         private long maxContentLen;
+        private int maxTotalHeaderCount;
         private int maxPartCount;
         private int maxNestingDepth;
         private boolean countLineNumbers;
@@ -238,6 +255,7 @@ public final class MimeConfig {
             this.maxHeaderCount = 1000;
             this.maxHeaderLen = 10000;
             this.maxContentLen = -1;
+            this.maxTotalHeaderCount = 16384;
             this.maxPartCount = 512;
             this.maxNestingDepth = 64;
             this.headlessParsing = null;
@@ -346,6 +364,29 @@ public final class MimeConfig {
         }
 
         /**
+         * Sets the maximum number of header fields a message may contain in
+         * total, across every entity. Parsing will be terminated with a
+         * {@link org.apache.james.mime4j.io.MaxHeaderLimitException} if a message
+         * carries more fields than this limit. If this parameter is set to a non
+         * positive value the total header count check will be disabled.
+         * <p>
+         * This complements {@link #setMaxHeaderCount(int)}, which is enforced per
+         * entity and therefore multiplies by {@link #setMaxPartCount(int)}: a
+         * message may hold few enough fields in every single entity yet still
+         * carry a very large number of them overall. Only a message wide budget
+         * bounds the retained header graph independently of the part count.
+         * <p>
+         * Default value: <code>16384</code>
+         *
+         * @param maxTotalHeaderCount
+         *            maximum total header count limit
+         */
+        public Builder setMaxTotalHeaderCount(int maxTotalHeaderCount) {
+            this.maxTotalHeaderCount = maxTotalHeaderCount;
+            return this;
+        }
+
+        /**
          * Sets the maximum number of MIME entities (body parts and embedded
          * messages) a message may be made of. Parsing will be terminated with a
          * {@link org.apache.james.mime4j.io.MaxPartCountLimitException} if a
@@ -429,6 +470,7 @@ public final class MimeConfig {
                     maxHeaderCount,
                     maxHeaderLen,
                     maxContentLen,
+                    maxTotalHeaderCount,
                     maxPartCount,
                     maxNestingDepth,
                     countLineNumbers,

--- a/core/src/main/java/org/apache/james/mime4j/stream/MimeConfig.java
+++ b/core/src/main/java/org/apache/james/mime4j/stream/MimeConfig.java
@@ -29,7 +29,7 @@ public final class MimeConfig {
     public static final MimeConfig PERMISSIVE = MimeConfig.custom()
         .setMaxContentLen(100 * 1024 * 1024)
         .setMaxHeaderCount(4096)
-        .setMaxHeaderLen(-1)
+        .setMaxHeaderLen(64 * 1024)
         .setMaxLineLen(-1)
         .build();
     public static final MimeConfig DEFAULT = new Builder().build();
@@ -44,6 +44,7 @@ public final class MimeConfig {
     private final int maxHeaderLen;
     private final long maxContentLen;
     private final int maxTotalHeaderCount;
+    private final long maxTotalHeaderLen;
     private final int maxPartCount;
     private final int maxNestingDepth;
     private final boolean countLineNumbers;
@@ -57,6 +58,7 @@ public final class MimeConfig {
             int maxHeaderLen,
             long maxContentLen,
             int maxTotalHeaderCount,
+            long maxTotalHeaderLen,
             int maxPartCount,
             int maxNestingDepth,
             boolean countLineNumbers,
@@ -70,6 +72,7 @@ public final class MimeConfig {
         this.maxHeaderLen = maxHeaderLen;
         this.maxContentLen = maxContentLen;
         this.maxTotalHeaderCount = maxTotalHeaderCount;
+        this.maxTotalHeaderLen = maxTotalHeaderLen;
         this.maxPartCount = maxPartCount;
         this.maxNestingDepth = maxNestingDepth;
         this.headlessParsing = headlessParsing;
@@ -152,6 +155,17 @@ public final class MimeConfig {
     }
 
     /**
+     * Returns the maximum total header length limit
+     *
+     * @see Builder#setMaxTotalHeaderLen(long)
+     *
+     * @return value of the maximum total header length limit
+     */
+    public long getMaxTotalHeaderLen() {
+        return maxTotalHeaderLen;
+    }
+
+    /**
      * Returns the maximum part count limit
      *
      * @see Builder#setMaxPartCount(int)
@@ -202,6 +216,7 @@ public final class MimeConfig {
                 .append(", maxHeaderLen=").append(maxHeaderLen)
                 .append(", maxContentLen=").append(maxContentLen)
                 .append(", maxTotalHeaderCount=").append(maxTotalHeaderCount)
+                .append(", maxTotalHeaderLen=").append(maxTotalHeaderLen)
                 .append(", maxPartCount=").append(maxPartCount)
                 .append(", maxNestingDepth=").append(maxNestingDepth)
                 .append(", countLineNumbers=").append(countLineNumbers)
@@ -226,6 +241,7 @@ public final class MimeConfig {
             .setMaxHeaderLen(config.getMaxHeaderLen())
             .setMaxContentLen(config.getMaxContentLen())
             .setMaxTotalHeaderCount(config.getMaxTotalHeaderCount())
+            .setMaxTotalHeaderLen(config.getMaxTotalHeaderLen())
             .setMaxPartCount(config.getMaxPartCount())
             .setMaxNestingDepth(config.getMaxNestingDepth())
             .setCountLineNumbers(config.isCountLineNumbers())
@@ -241,6 +257,7 @@ public final class MimeConfig {
         private int maxHeaderLen;
         private long maxContentLen;
         private int maxTotalHeaderCount;
+        private long maxTotalHeaderLen;
         private int maxPartCount;
         private int maxNestingDepth;
         private boolean countLineNumbers;
@@ -256,6 +273,7 @@ public final class MimeConfig {
             this.maxHeaderLen = 10000;
             this.maxContentLen = -1;
             this.maxTotalHeaderCount = 16384;
+            this.maxTotalHeaderLen = 1024 * 1024;
             this.maxPartCount = 512;
             this.maxNestingDepth = 64;
             this.headlessParsing = null;
@@ -387,6 +405,31 @@ public final class MimeConfig {
         }
 
         /**
+         * Sets the maximum number of bytes a message may spend on header fields in
+         * total, across every entity. Parsing will be terminated with a
+         * {@link org.apache.james.mime4j.io.MaxHeaderLengthLimitException} if a
+         * message carries more header bytes than this limit. If this parameter is
+         * set to a non positive value the total header length check is disabled.
+         * <p>
+         * This is to {@link #setMaxHeaderLen(int)} what
+         * {@link #setMaxTotalHeaderCount(int)} is to {@link #setMaxHeaderCount(int)}.
+         * A per header bound multiplies by the number of entities: {@code Content-Type}
+         * and {@code Content-Disposition} occur once per part, so bounding each one
+         * still leaves {@link #setMaxPartCount(int)} times that much. Address, group
+         * and parameter lists are retained as one object per item, so only a message
+         * wide budget on header bytes bounds the retained graph.
+         * <p>
+         * Default value: <code>1048576</code> (1 MB)
+         *
+         * @param maxTotalHeaderLen
+         *            maximum total header length limit
+         */
+        public Builder setMaxTotalHeaderLen(long maxTotalHeaderLen) {
+            this.maxTotalHeaderLen = maxTotalHeaderLen;
+            return this;
+        }
+
+        /**
          * Sets the maximum number of MIME entities (body parts and embedded
          * messages) a message may be made of. Parsing will be terminated with a
          * {@link org.apache.james.mime4j.io.MaxPartCountLimitException} if a
@@ -471,6 +514,7 @@ public final class MimeConfig {
                     maxHeaderLen,
                     maxContentLen,
                     maxTotalHeaderCount,
+                    maxTotalHeaderLen,
                     maxPartCount,
                     maxNestingDepth,
                     countLineNumbers,

--- a/core/src/main/java/org/apache/james/mime4j/stream/MimeConfig.java
+++ b/core/src/main/java/org/apache/james/mime4j/stream/MimeConfig.java
@@ -43,6 +43,8 @@ public final class MimeConfig {
     private final int maxHeaderCount;
     private final int maxHeaderLen;
     private final long maxContentLen;
+    private final int maxPartCount;
+    private final int maxNestingDepth;
     private final boolean countLineNumbers;
     private final String headlessParsing;
     private final boolean malformedHeaderStartsBody;
@@ -53,6 +55,8 @@ public final class MimeConfig {
             int maxHeaderCount,
             int maxHeaderLen,
             long maxContentLen,
+            int maxPartCount,
+            int maxNestingDepth,
             boolean countLineNumbers,
             String headlessParsing,
             boolean malformedHeaderStartsBody) {
@@ -63,6 +67,8 @@ public final class MimeConfig {
         this.maxHeaderCount = maxHeaderCount;
         this.maxHeaderLen = maxHeaderLen;
         this.maxContentLen = maxContentLen;
+        this.maxPartCount = maxPartCount;
+        this.maxNestingDepth = maxNestingDepth;
         this.headlessParsing = headlessParsing;
     }
 
@@ -132,6 +138,28 @@ public final class MimeConfig {
     }
 
     /**
+     * Returns the maximum part count limit
+     *
+     * @see Builder#setMaxPartCount(int)
+     *
+     * @return value of the maximum part count limit
+     */
+    public int getMaxPartCount() {
+        return maxPartCount;
+    }
+
+    /**
+     * Returns the maximum nesting depth limit
+     *
+     * @see Builder#setMaxNestingDepth(int)
+     *
+     * @return value of the maximum nesting depth limit
+     */
+    public int getMaxNestingDepth() {
+        return maxNestingDepth;
+    }
+
+    /**
      * Returns the value of the line number counting mode.
      *
      * @return value of the line number counting mode.
@@ -159,6 +187,8 @@ public final class MimeConfig {
                 .append(", maxHeaderCount=").append(maxHeaderCount)
                 .append(", maxHeaderLen=").append(maxHeaderLen)
                 .append(", maxContentLen=").append(maxContentLen)
+                .append(", maxPartCount=").append(maxPartCount)
+                .append(", maxNestingDepth=").append(maxNestingDepth)
                 .append(", countLineNumbers=").append(countLineNumbers)
                 .append(", headlessParsing=").append(headlessParsing)
                 .append(", malformedHeaderStartsBody=").append(malformedHeaderStartsBody)
@@ -180,6 +210,8 @@ public final class MimeConfig {
             .setMaxHeaderCount(config.getMaxHeaderCount())
             .setMaxHeaderLen(config.getMaxHeaderLen())
             .setMaxContentLen(config.getMaxContentLen())
+            .setMaxPartCount(config.getMaxPartCount())
+            .setMaxNestingDepth(config.getMaxNestingDepth())
             .setCountLineNumbers(config.isCountLineNumbers())
             .setHeadlessParsing(config.getHeadlessParsing())
             .setMalformedHeaderStartsBody(config.isMalformedHeaderStartsBody());
@@ -192,6 +224,8 @@ public final class MimeConfig {
         private int maxHeaderCount;
         private int maxHeaderLen;
         private long maxContentLen;
+        private int maxPartCount;
+        private int maxNestingDepth;
         private boolean countLineNumbers;
         private String headlessParsing;
         private boolean malformedHeaderStartsBody;
@@ -204,6 +238,8 @@ public final class MimeConfig {
             this.maxHeaderCount = 1000;
             this.maxHeaderLen = 10000;
             this.maxContentLen = -1;
+            this.maxPartCount = 512;
+            this.maxNestingDepth = 64;
             this.headlessParsing = null;
         }
 
@@ -310,6 +346,53 @@ public final class MimeConfig {
         }
 
         /**
+         * Sets the maximum number of MIME entities (body parts and embedded
+         * messages) a message may be made of. Parsing will be terminated with a
+         * {@link org.apache.james.mime4j.io.MaxPartCountLimitException} if a
+         * message contains more entities than this limit. If this parameter is
+         * set to a non positive value the part count check will be disabled.
+         * <p>
+         * The top level message itself is not counted, so a limit of
+         * <code>1</code> allows a multipart message holding a single body part.
+         * <p>
+         * Unlike {@link #setMaxHeaderCount(int)} and
+         * {@link #setMaxContentLen(long)}, which are enforced per entity, this
+         * limit applies to the message as a whole. Without it a small message
+         * made of a very large number of tiny parts can make a consumer
+         * building an object graph per part exhaust its memory.
+         * <p>
+         * Default value: <code>512</code>
+         *
+         * @param maxPartCount
+         *            maximum part count limit
+         */
+        public Builder setMaxPartCount(int maxPartCount) {
+            this.maxPartCount = maxPartCount;
+            return this;
+        }
+
+        /**
+         * Sets the maximum nesting depth of MIME entities. Parsing will be
+         * terminated with a
+         * {@link org.apache.james.mime4j.io.MaxNestingDepthLimitException} if
+         * entities are nested more deeply than this limit. If this parameter is
+         * set to a non positive value the nesting depth check will be disabled.
+         * <p>
+         * The top level message is at depth <code>1</code>, so a limit of
+         * <code>2</code> allows a multipart message whose body parts are not
+         * themselves multipart or embedded messages.
+         * <p>
+         * Default value: <code>64</code>
+         *
+         * @param maxNestingDepth
+         *            maximum nesting depth limit
+         */
+        public Builder setMaxNestingDepth(int maxNestingDepth) {
+            this.maxNestingDepth = maxNestingDepth;
+            return this;
+        }
+
+        /**
          * Defines whether the parser should count line numbers. If enabled line
          * numbers are included in the debug output.
          * <p>
@@ -346,6 +429,8 @@ public final class MimeConfig {
                     maxHeaderCount,
                     maxHeaderLen,
                     maxContentLen,
+                    maxPartCount,
+                    maxNestingDepth,
                     countLineNumbers,
                     headlessParsing,
                     malformedHeaderStartsBody);

--- a/core/src/main/java/org/apache/james/mime4j/stream/MimeTokenStream.java
+++ b/core/src/main/java/org/apache/james/mime4j/stream/MimeTokenStream.java
@@ -31,6 +31,8 @@ import org.apache.james.mime4j.Charsets;
 import org.apache.james.mime4j.MimeException;
 import org.apache.james.mime4j.codec.DecodeMonitor;
 import org.apache.james.mime4j.io.LineNumberInputStream;
+import org.apache.james.mime4j.io.MaxNestingDepthLimitException;
+import org.apache.james.mime4j.io.MaxPartCountLimitException;
 import org.apache.james.mime4j.util.CharsetUtil;
 
 /**
@@ -88,6 +90,7 @@ public class MimeTokenStream {
     private EntityStateMachine currentStateMachine;
     private RecursionMode recursionMode = RecursionMode.M_RECURSE;
     private MimeEntity rootentity;
+    private int partCount;
 
     /**
      * Constructs a standard (lax) stream.
@@ -204,6 +207,7 @@ public class MimeTokenStream {
 
         rootentity.setRecursionMode(recursionMode);
         currentStateMachine = rootentity;
+        partCount = 0;
         entities.clear();
         entities.add(currentStateMachine);
         state = currentStateMachine.getState();
@@ -374,6 +378,7 @@ public class MimeTokenStream {
         while (currentStateMachine != null) {
             EntityStateMachine next = currentStateMachine.advance();
             if (next != null) {
+                checkEntityLimits();
                 entities.add(next);
                 currentStateMachine = next;
             }
@@ -394,6 +399,31 @@ public class MimeTokenStream {
         }
         state = EntityState.T_END_OF_STREAM;
         return state;
+    }
+
+    /**
+     * Enforces the limits on the total number of MIME entities a message may be
+     * made of and on how deeply those entities may be nested. Both are message
+     * wide limits, unlike the header and content limits which are enforced per
+     * entity, and they bound the work a consumer of this token stream can be
+     * made to do by a small but pathologically structured message.
+     * <p>
+     * Called before a newly discovered entity is pushed onto the stack.
+     */
+    private void checkEntityLimits() throws MimeException {
+        int maxPartCount = config.getMaxPartCount();
+        if (maxPartCount > 0 && partCount >= maxPartCount) {
+            throw new MaxPartCountLimitException("Maximum part count limit ("
+                    + maxPartCount + ") exceeded");
+        }
+        partCount++;
+        int maxNestingDepth = config.getMaxNestingDepth();
+        // entities already holds the parent chain of the entity being pushed,
+        // the root message included, so the new entity sits at depth size + 1.
+        if (maxNestingDepth > 0 && entities.size() >= maxNestingDepth) {
+            throw new MaxNestingDepthLimitException("Maximum nesting depth limit ("
+                    + maxNestingDepth + ") exceeded");
+        }
     }
 
     /**

--- a/core/src/main/java/org/apache/james/mime4j/stream/MimeTokenStream.java
+++ b/core/src/main/java/org/apache/james/mime4j/stream/MimeTokenStream.java
@@ -31,9 +31,11 @@ import org.apache.james.mime4j.Charsets;
 import org.apache.james.mime4j.MimeException;
 import org.apache.james.mime4j.codec.DecodeMonitor;
 import org.apache.james.mime4j.io.LineNumberInputStream;
+import org.apache.james.mime4j.io.MaxHeaderLengthLimitException;
 import org.apache.james.mime4j.io.MaxHeaderLimitException;
 import org.apache.james.mime4j.io.MaxNestingDepthLimitException;
 import org.apache.james.mime4j.io.MaxPartCountLimitException;
+import org.apache.james.mime4j.util.ByteSequence;
 import org.apache.james.mime4j.util.CharsetUtil;
 
 /**
@@ -93,6 +95,7 @@ public class MimeTokenStream {
     private MimeEntity rootentity;
     private int partCount;
     private int totalHeaderCount;
+    private long totalHeaderLen;
 
     /**
      * Constructs a standard (lax) stream.
@@ -211,6 +214,7 @@ public class MimeTokenStream {
         currentStateMachine = rootentity;
         partCount = 0;
         totalHeaderCount = 0;
+        totalHeaderLen = 0;
         entities.clear();
         entities.add(currentStateMachine);
         state = currentStateMachine.getState();
@@ -388,7 +392,7 @@ public class MimeTokenStream {
             state = currentStateMachine.getState();
             if (state != EntityState.T_END_OF_STREAM) {
                 if (state == EntityState.T_FIELD) {
-                    checkTotalHeaderLimit();
+                    checkTotalHeaderLimits();
                 }
                 return state;
             }
@@ -440,16 +444,43 @@ public class MimeTokenStream {
      * a consumer building a DOM, so only a message wide budget bounds that graph
      * independently of the part count.
      * <p>
+     * The same reasoning applies to header bytes: {@link MimeConfig#getMaxHeaderLen()}
+     * bounds one field, but {@code Content-Type} and {@code Content-Disposition}
+     * occur once per entity and so multiply by the part count.
+     * <p>
      * Counts the fields actually reported to the caller: malformed fields the
      * parser skips are not retained and so do not consume the budget.
      */
-    private void checkTotalHeaderLimit() throws MimeException {
+    private void checkTotalHeaderLimits() throws MimeException {
         int maxTotalHeaderCount = config.getMaxTotalHeaderCount();
         totalHeaderCount++;
         if (maxTotalHeaderCount > 0 && totalHeaderCount > maxTotalHeaderCount) {
             throw new MaxHeaderLimitException("Maximum total header limit ("
                     + maxTotalHeaderCount + ") exceeded");
         }
+        long maxTotalHeaderLen = config.getMaxTotalHeaderLen();
+        if (maxTotalHeaderLen > 0) {
+            totalHeaderLen += rawLengthOf(currentStateMachine.getField());
+            if (totalHeaderLen > maxTotalHeaderLen) {
+                throw new MaxHeaderLengthLimitException("Maximum total header length limit ("
+                        + maxTotalHeaderLen + ") exceeded");
+            }
+        }
+    }
+
+    /**
+     * Size of a field as it appeared on the wire. Falls back to the rendered length
+     * when a field carries no raw bytes, rather than calling {@code getSafeRaw()}
+     * which would allocate them just to measure them.
+     */
+    private static int rawLengthOf(Field field) {
+        ByteSequence raw = field.getRaw();
+        if (raw != null) {
+            return raw.length();
+        }
+        String name = field.getName();
+        String body = field.getBody();
+        return (name != null ? name.length() : 0) + (body != null ? body.length() : 0) + 4;
     }
 
     /**

--- a/core/src/main/java/org/apache/james/mime4j/stream/MimeTokenStream.java
+++ b/core/src/main/java/org/apache/james/mime4j/stream/MimeTokenStream.java
@@ -31,6 +31,7 @@ import org.apache.james.mime4j.Charsets;
 import org.apache.james.mime4j.MimeException;
 import org.apache.james.mime4j.codec.DecodeMonitor;
 import org.apache.james.mime4j.io.LineNumberInputStream;
+import org.apache.james.mime4j.io.MaxHeaderLimitException;
 import org.apache.james.mime4j.io.MaxNestingDepthLimitException;
 import org.apache.james.mime4j.io.MaxPartCountLimitException;
 import org.apache.james.mime4j.util.CharsetUtil;
@@ -91,6 +92,7 @@ public class MimeTokenStream {
     private RecursionMode recursionMode = RecursionMode.M_RECURSE;
     private MimeEntity rootentity;
     private int partCount;
+    private int totalHeaderCount;
 
     /**
      * Constructs a standard (lax) stream.
@@ -208,6 +210,7 @@ public class MimeTokenStream {
         rootentity.setRecursionMode(recursionMode);
         currentStateMachine = rootentity;
         partCount = 0;
+        totalHeaderCount = 0;
         entities.clear();
         entities.add(currentStateMachine);
         state = currentStateMachine.getState();
@@ -384,6 +387,9 @@ public class MimeTokenStream {
             }
             state = currentStateMachine.getState();
             if (state != EntityState.T_END_OF_STREAM) {
+                if (state == EntityState.T_FIELD) {
+                    checkTotalHeaderLimit();
+                }
                 return state;
             }
             final EntityStateMachine entityStateMachine = entities.removeLast();
@@ -423,6 +429,26 @@ public class MimeTokenStream {
         if (maxNestingDepth > 0 && entities.size() >= maxNestingDepth) {
             throw new MaxNestingDepthLimitException("Maximum nesting depth limit ("
                     + maxNestingDepth + ") exceeded");
+        }
+    }
+
+    /**
+     * Enforces the message wide budget on header fields. {@link MimeConfig#getMaxHeaderCount()}
+     * is enforced per entity by {@link MimeEntity} and so resets on every part,
+     * which lets a message stay under it in every single entity while still
+     * carrying a very large number of fields overall. Every field is retained by
+     * a consumer building a DOM, so only a message wide budget bounds that graph
+     * independently of the part count.
+     * <p>
+     * Counts the fields actually reported to the caller: malformed fields the
+     * parser skips are not retained and so do not consume the budget.
+     */
+    private void checkTotalHeaderLimit() throws MimeException {
+        int maxTotalHeaderCount = config.getMaxTotalHeaderCount();
+        totalHeaderCount++;
+        if (maxTotalHeaderCount > 0 && totalHeaderCount > maxTotalHeaderCount) {
+            throw new MaxHeaderLimitException("Maximum total header limit ("
+                    + maxTotalHeaderCount + ") exceeded");
         }
     }
 

--- a/core/src/main/java/org/apache/james/mime4j/util/MimeParameterMapping.java
+++ b/core/src/main/java/org/apache/james/mime4j/util/MimeParameterMapping.java
@@ -73,7 +73,7 @@ public class MimeParameterMapping {
     private final Set<String> parameterNames = new HashSet<>();
     private final Map<String, String> standard = new HashMap<>();
     private final Map<String, String> extended = new HashMap<>();
-    private final Map<String, String> continuation = new HashMap<>();
+    private final Map<String, StringBuilder> continuation = new HashMap<>();
 
     private final Map<String, String> parameters = new HashMap<>();
     private boolean needToUpdate = true;
@@ -122,7 +122,7 @@ public class MimeParameterMapping {
         }
         if (continuation.containsKey(name)) {
             try {
-                return decodeParameterValue(continuation.get(name));
+                return decodeParameterValue(continuation.get(name).toString());
             } catch (DecodeException e) {
                 //ignore and try standard
             }
@@ -141,7 +141,7 @@ public class MimeParameterMapping {
         }
 
         if (continuation.containsKey(name)) {
-            return continuation.get(name);
+            return continuation.get(name).toString();
         }
 
         if (extended.containsKey(name)) {
@@ -160,12 +160,8 @@ public class MimeParameterMapping {
                 extended.putIfAbsent(parameterTypePair.fieldName, value);
                 break;
             case CONTINUATION:
-                if (continuation.containsKey(parameterTypePair.fieldName)) {
-                    String newValue = continuation.get(parameterTypePair.fieldName) + value;
-                    continuation.put(parameterTypePair.fieldName, newValue);
-                } else {
-                    continuation.put(parameterTypePair.fieldName, value);
-                }
+                continuation.computeIfAbsent(parameterTypePair.fieldName, k -> new StringBuilder())
+                        .append(value);
                 break;
             case STANDARD:
                 standard.putIfAbsent(parameterTypePair.fieldName, value);

--- a/core/src/test/java/org/apache/james/mime4j/stream/MimeEntityLimitsTest.java
+++ b/core/src/test/java/org/apache/james/mime4j/stream/MimeEntityLimitsTest.java
@@ -1,0 +1,253 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mime4j.stream;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import org.apache.james.mime4j.Charsets;
+import org.apache.james.mime4j.io.MaxNestingDepthLimitException;
+import org.apache.james.mime4j.io.MaxPartCountLimitException;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests the message wide limits bounding the number of MIME entities a message
+ * may be made of and how deeply they may be nested.
+ */
+public class MimeEntityLimitsTest {
+
+    /**
+     * A multipart message made of <code>count</code> empty body parts. Each part
+     * costs about 10 bytes on the wire but makes a consumer building an object
+     * graph per part allocate far more than that.
+     */
+    private static InputStream flatMultipart(int count) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Content-Type: multipart/mixed; boundary=b\r\n\r\n");
+        for (int i = 0; i < count; i++) {
+            sb.append("--b\r\n\r\n");
+        }
+        sb.append("--b--\r\n");
+        return new ByteArrayInputStream(sb.toString().getBytes(Charsets.US_ASCII));
+    }
+
+    /**
+     * A message of nested multiparts, <code>depth</code> levels deep. The top
+     * level message is at depth 1, so the innermost body part is at depth
+     * <code>depth</code>.
+     */
+    private static InputStream nestedMultipart(int depth) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 1; i < depth; i++) {
+            sb.append("Content-Type: multipart/mixed; boundary=b").append(i).append("\r\n\r\n");
+            sb.append("--b").append(i).append("\r\n");
+        }
+        sb.append("\r\n");
+        for (int i = depth - 1; i >= 1; i--) {
+            sb.append("--b").append(i).append("--\r\n");
+        }
+        return new ByteArrayInputStream(sb.toString().getBytes(Charsets.US_ASCII));
+    }
+
+    private static int parse(MimeConfig config, InputStream in) throws Exception {
+        MimeTokenStream stream = new MimeTokenStream(config);
+        stream.parse(in);
+        int parts = 0;
+        for (EntityState state = stream.getState();
+             state != EntityState.T_END_OF_STREAM;
+             state = stream.next()) {
+            if (state == EntityState.T_START_BODYPART) {
+                parts++;
+            }
+        }
+        return parts;
+    }
+
+    @Test
+    public void partCountLimitShouldAcceptAMessageAtTheLimit() throws Exception {
+        MimeConfig config = MimeConfig.custom().setMaxPartCount(3).build();
+        Assert.assertEquals(3, parse(config, flatMultipart(3)));
+    }
+
+    @Test
+    public void partCountLimitShouldRejectAMessageOverTheLimit() throws Exception {
+        MimeConfig config = MimeConfig.custom().setMaxPartCount(3).build();
+        try {
+            parse(config, flatMultipart(4));
+            Assert.fail("MaxPartCountLimitException expected");
+        } catch (MaxPartCountLimitException expected) {
+            Assert.assertEquals("Maximum part count limit (3) exceeded", expected.getMessage());
+        }
+    }
+
+    @Test
+    public void partCountLimitShouldBeDisabledWhenNegative() throws Exception {
+        MimeConfig config = MimeConfig.custom().setMaxPartCount(-1).build();
+        Assert.assertEquals(2000, parse(config, flatMultipart(2000)));
+    }
+
+    @Test
+    public void partCountLimitShouldBeDisabledWhenZero() throws Exception {
+        MimeConfig config = MimeConfig.custom().setMaxPartCount(0).build();
+        Assert.assertEquals(2000, parse(config, flatMultipart(2000)));
+    }
+
+    @Test
+    public void partCountLimitShouldBeDisabledOnACopyOfPermissive() throws Exception {
+        MimeConfig config = MimeConfig.copy(MimeConfig.PERMISSIVE).setMaxPartCount(-1).build();
+        Assert.assertEquals(-1, config.getMaxPartCount());
+        Assert.assertEquals(2000, parse(config, flatMultipart(2000)));
+    }
+
+    @Test
+    public void partCountLimitShouldCountEmbeddedMessages() throws Exception {
+        // multipart/mixed holding one message/rfc822: the body part and the
+        // embedded message are two entities.
+        String message = "Content-Type: multipart/mixed; boundary=b\r\n\r\n"
+                + "--b\r\n"
+                + "Content-Type: message/rfc822\r\n\r\n"
+                + "Subject: embedded\r\n\r\n"
+                + "body\r\n"
+                + "--b--\r\n";
+        InputStream in = new ByteArrayInputStream(message.getBytes(Charsets.US_ASCII));
+        try {
+            parse(MimeConfig.custom().setMaxPartCount(1).build(), in);
+            Assert.fail("MaxPartCountLimitException expected");
+        } catch (MaxPartCountLimitException expected) {
+            // expected
+        }
+    }
+
+    @Test
+    public void defaultConfigShouldAcceptAMessageWithinThePartCountDefault() throws Exception {
+        Assert.assertEquals(512, parse(MimeConfig.DEFAULT, flatMultipart(512)));
+    }
+
+    @Test
+    public void defaultConfigShouldBoundThePartCount() throws Exception {
+        try {
+            parse(MimeConfig.DEFAULT, flatMultipart(513));
+            Assert.fail("MaxPartCountLimitException expected");
+        } catch (MaxPartCountLimitException expected) {
+            // expected
+        }
+    }
+
+    @Test
+    public void permissiveConfigShouldBoundThePartCount() throws Exception {
+        try {
+            parse(MimeConfig.PERMISSIVE, flatMultipart(513));
+            Assert.fail("MaxPartCountLimitException expected");
+        } catch (MaxPartCountLimitException expected) {
+            // expected
+        }
+    }
+
+    @Test
+    public void nestingDepthLimitShouldAcceptAMessageAtTheLimit() throws Exception {
+        MimeConfig config = MimeConfig.custom()
+                .setMaxNestingDepth(4)
+                .setMaxPartCount(-1)
+                .build();
+        Assert.assertEquals(3, parse(config, nestedMultipart(4)));
+    }
+
+    @Test
+    public void nestingDepthLimitShouldRejectAMessageOverTheLimit() throws Exception {
+        MimeConfig config = MimeConfig.custom()
+                .setMaxNestingDepth(4)
+                .setMaxPartCount(-1)
+                .build();
+        try {
+            parse(config, nestedMultipart(5));
+            Assert.fail("MaxNestingDepthLimitException expected");
+        } catch (MaxNestingDepthLimitException expected) {
+            Assert.assertEquals("Maximum nesting depth limit (4) exceeded", expected.getMessage());
+        }
+    }
+
+    @Test
+    public void nestingDepthLimitShouldBeDisabledWhenNegative() throws Exception {
+        MimeConfig config = MimeConfig.custom()
+                .setMaxNestingDepth(-1)
+                .setMaxPartCount(-1)
+                .build();
+        Assert.assertEquals(199, parse(config, nestedMultipart(200)));
+    }
+
+    @Test
+    public void nestingDepthLimitShouldBeDisabledWhenZero() throws Exception {
+        MimeConfig config = MimeConfig.custom()
+                .setMaxNestingDepth(0)
+                .setMaxPartCount(0)
+                .build();
+        Assert.assertEquals(199, parse(config, nestedMultipart(200)));
+    }
+
+    @Test
+    public void nestingDepthLimitShouldBeDisabledOnACopyOfPermissive() throws Exception {
+        MimeConfig config = MimeConfig.copy(MimeConfig.PERMISSIVE)
+                .setMaxNestingDepth(-1)
+                .setMaxPartCount(-1)
+                .build();
+        Assert.assertEquals(-1, config.getMaxNestingDepth());
+        Assert.assertEquals(199, parse(config, nestedMultipart(200)));
+    }
+
+    @Test
+    public void defaultConfigShouldAcceptAMessageWithinTheNestingDepthDefault() throws Exception {
+        MimeConfig config = MimeConfig.copy(MimeConfig.DEFAULT).setMaxPartCount(-1).build();
+        Assert.assertEquals(63, parse(config, nestedMultipart(64)));
+    }
+
+    @Test
+    public void defaultConfigShouldBoundTheNestingDepth() throws Exception {
+        MimeConfig config = MimeConfig.copy(MimeConfig.DEFAULT).setMaxPartCount(-1).build();
+        try {
+            parse(config, nestedMultipart(65));
+            Assert.fail("MaxNestingDepthLimitException expected");
+        } catch (MaxNestingDepthLimitException expected) {
+            // expected
+        }
+    }
+
+    @Test
+    public void limitsShouldBeResetBetweenParses() throws Exception {
+        MimeConfig config = MimeConfig.custom().setMaxPartCount(3).build();
+        MimeTokenStream stream = new MimeTokenStream(config);
+        for (int i = 0; i < 3; i++) {
+            stream.parse(flatMultipart(3));
+            while (stream.getState() != EntityState.T_END_OF_STREAM) {
+                stream.next();
+            }
+        }
+    }
+
+    @Test
+    public void copyShouldCarryTheLimitsOver() {
+        MimeConfig config = MimeConfig.copy(MimeConfig.custom()
+                .setMaxPartCount(7)
+                .setMaxNestingDepth(9)
+                .build()).build();
+        Assert.assertEquals(7, config.getMaxPartCount());
+        Assert.assertEquals(9, config.getMaxNestingDepth());
+    }
+}

--- a/core/src/test/java/org/apache/james/mime4j/stream/MimeEntityLimitsTest.java
+++ b/core/src/test/java/org/apache/james/mime4j/stream/MimeEntityLimitsTest.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
 import org.apache.james.mime4j.Charsets;
+import org.apache.james.mime4j.io.MaxHeaderLimitException;
 import org.apache.james.mime4j.io.MaxNestingDepthLimitException;
 import org.apache.james.mime4j.io.MaxPartCountLimitException;
 import org.junit.Assert;
@@ -242,12 +243,116 @@ public class MimeEntityLimitsTest {
     }
 
     @Test
+    public void permissiveConfigShouldBoundTheHeaderCount() throws Exception {
+        Assert.assertEquals(4096, MimeConfig.PERMISSIVE.getMaxHeaderCount());
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 4097; i++) {
+            sb.append("x:\r\n");
+        }
+        sb.append("\r\nbody\r\n");
+        InputStream in = new ByteArrayInputStream(sb.toString().getBytes(Charsets.US_ASCII));
+        try {
+            parse(MimeConfig.PERMISSIVE, in);
+            Assert.fail("MaxHeaderLimitException expected");
+        } catch (MaxHeaderLimitException expected) {
+            // expected
+        }
+    }
+
+    /** A multipart of {@code parts} body parts, each carrying {@code headers} fields. */
+    private static InputStream multipartWithHeaders(int parts, int headers) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Content-Type: multipart/mixed; boundary=b\r\n\r\n");
+        for (int p = 0; p < parts; p++) {
+            sb.append("--b\r\n");
+            for (int h = 0; h < headers; h++) {
+                sb.append("x:\r\n");
+            }
+            sb.append("\r\n");
+        }
+        sb.append("--b--\r\n");
+        return new ByteArrayInputStream(sb.toString().getBytes(Charsets.US_ASCII));
+    }
+
+    @Test
+    public void totalHeaderLimitShouldAccumulateAcrossEntities() throws Exception {
+        // 5 parts x 3 fields = 15 fields, none of which trips the per entity limit
+        MimeConfig config = MimeConfig.custom()
+                .setMaxHeaderCount(1000)
+                .setMaxTotalHeaderCount(10)
+                .build();
+        try {
+            parse(config, multipartWithHeaders(5, 3));
+            Assert.fail("MaxHeaderLimitException expected");
+        } catch (MaxHeaderLimitException expected) {
+            Assert.assertEquals("Maximum total header limit (10) exceeded", expected.getMessage());
+        }
+    }
+
+    @Test
+    public void totalHeaderLimitShouldAcceptAMessageAtTheLimit() throws Exception {
+        // 5 parts x 3 fields, plus the root message's own Content-Type field
+        MimeConfig config = MimeConfig.custom()
+                .setMaxHeaderCount(1000)
+                .setMaxTotalHeaderCount(5 * 3 + 1)
+                .build();
+        Assert.assertEquals(5, parse(config, multipartWithHeaders(5, 3)));
+    }
+
+    @Test
+    public void totalHeaderLimitShouldCountTheRootMessageFields() throws Exception {
+        MimeConfig config = MimeConfig.custom()
+                .setMaxHeaderCount(1000)
+                .setMaxTotalHeaderCount(5 * 3)
+                .build();
+        try {
+            parse(config, multipartWithHeaders(5, 3));
+            Assert.fail("MaxHeaderLimitException expected");
+        } catch (MaxHeaderLimitException expected) {
+            // the root Content-Type is the 16th field
+        }
+    }
+
+    @Test
+    public void totalHeaderLimitShouldBeDisabledWhenNegative() throws Exception {
+        MimeConfig config = MimeConfig.custom()
+                .setMaxHeaderCount(-1)
+                .setMaxTotalHeaderCount(-1)
+                .build();
+        Assert.assertEquals(50, parse(config, multipartWithHeaders(50, 100)));
+    }
+
+    @Test
+    public void totalHeaderLimitShouldBeDisabledWhenZero() throws Exception {
+        MimeConfig config = MimeConfig.custom()
+                .setMaxHeaderCount(-1)
+                .setMaxTotalHeaderCount(0)
+                .build();
+        Assert.assertEquals(50, parse(config, multipartWithHeaders(50, 100)));
+    }
+
+    @Test
+    public void defaultConfigShouldBoundTheTotalHeaderCount() throws Exception {
+        Assert.assertEquals(16384, MimeConfig.DEFAULT.getMaxTotalHeaderCount());
+        Assert.assertEquals(16384, MimeConfig.PERMISSIVE.getMaxTotalHeaderCount());
+        try {
+            // 400 parts x 100 fields = 40000 fields, only 100 per entity
+            parse(MimeConfig.PERMISSIVE, multipartWithHeaders(400, 100));
+            Assert.fail("MaxHeaderLimitException expected");
+        } catch (MaxHeaderLimitException expected) {
+            // expected
+        }
+    }
+
+    @Test
     public void copyShouldCarryTheLimitsOver() {
         MimeConfig config = MimeConfig.copy(MimeConfig.custom()
                 .setMaxPartCount(7)
                 .setMaxNestingDepth(9)
+                .setMaxTotalHeaderCount(11)
                 .build()).build();
         Assert.assertEquals(7, config.getMaxPartCount());
         Assert.assertEquals(9, config.getMaxNestingDepth());
+        Assert.assertEquals(11, config.getMaxTotalHeaderCount());
     }
 }

--- a/core/src/test/java/org/apache/james/mime4j/stream/MimeEntityLimitsTest.java
+++ b/core/src/test/java/org/apache/james/mime4j/stream/MimeEntityLimitsTest.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
 import org.apache.james.mime4j.Charsets;
+import org.apache.james.mime4j.io.MaxHeaderLengthLimitException;
 import org.apache.james.mime4j.io.MaxHeaderLimitException;
 import org.apache.james.mime4j.io.MaxNestingDepthLimitException;
 import org.apache.james.mime4j.io.MaxPartCountLimitException;
@@ -344,15 +345,109 @@ public class MimeEntityLimitsTest {
         }
     }
 
+    /** A multipart whose every part carries one header of {@code bytes} octets. */
+    private static InputStream multipartWithFatHeaders(int parts, int bytes) {
+        StringBuilder pad = new StringBuilder("x: ");
+        while (pad.length() < bytes) {
+            pad.append('a');
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append("Content-Type: multipart/mixed; boundary=b\r\n\r\n");
+        for (int p = 0; p < parts; p++) {
+            sb.append("--b\r\n").append(pad).append("\r\n\r\n");
+        }
+        sb.append("--b--\r\n");
+        return new ByteArrayInputStream(sb.toString().getBytes(Charsets.US_ASCII));
+    }
+
+    @Test
+    public void totalHeaderLengthShouldAccumulateAcrossEntities() throws Exception {
+        // 20 parts x 1000 octets: no single header is anywhere near maxHeaderLen
+        MimeConfig config = MimeConfig.custom()
+                .setMaxLineLen(-1)
+                .setMaxHeaderLen(-1)
+                .setMaxTotalHeaderLen(10000)
+                .build();
+        try {
+            parse(config, multipartWithFatHeaders(20, 1000));
+            Assert.fail("MaxHeaderLengthLimitException expected");
+        } catch (MaxHeaderLengthLimitException expected) {
+            Assert.assertTrue(expected.getMessage(),
+                    expected.getMessage().startsWith("Maximum total header length limit (10000)"));
+        }
+    }
+
+    @Test
+    public void totalHeaderLengthShouldAcceptAMessageWithinTheLimit() throws Exception {
+        MimeConfig config = MimeConfig.custom()
+                .setMaxLineLen(-1)
+                .setMaxHeaderLen(-1)
+                .setMaxTotalHeaderLen(1024 * 1024)
+                .build();
+        Assert.assertEquals(20, parse(config, multipartWithFatHeaders(20, 1000)));
+    }
+
+    @Test
+    public void totalHeaderLengthShouldBeDisabledWhenNegative() throws Exception {
+        MimeConfig config = MimeConfig.custom()
+                .setMaxLineLen(-1)
+                .setMaxHeaderLen(-1)
+                .setMaxTotalHeaderLen(-1)
+                .build();
+        Assert.assertEquals(20, parse(config, multipartWithFatHeaders(20, 100000)));
+    }
+
+    @Test
+    public void totalHeaderLengthShouldBeDisabledWhenZero() throws Exception {
+        MimeConfig config = MimeConfig.custom()
+                .setMaxLineLen(-1)
+                .setMaxHeaderLen(-1)
+                .setMaxTotalHeaderLen(0)
+                .build();
+        Assert.assertEquals(20, parse(config, multipartWithFatHeaders(20, 100000)));
+    }
+
+    @Test
+    public void defaultConfigShouldBoundTheTotalHeaderLength() throws Exception {
+        Assert.assertEquals(1024 * 1024, MimeConfig.DEFAULT.getMaxTotalHeaderLen());
+        Assert.assertEquals(1024 * 1024, MimeConfig.PERMISSIVE.getMaxTotalHeaderLen());
+        try {
+            // 512 parts x 8 KB of headers = 4 MB, no single header over 64 KB
+            parse(MimeConfig.PERMISSIVE, multipartWithFatHeaders(512, 8192));
+            Assert.fail("MaxHeaderLengthLimitException expected");
+        } catch (MaxHeaderLengthLimitException expected) {
+            // expected
+        }
+    }
+
+    @Test
+    public void permissiveConfigShouldBoundASingleHeaderLength() throws Exception {
+        Assert.assertEquals(64 * 1024, MimeConfig.PERMISSIVE.getMaxHeaderLen());
+        StringBuilder sb = new StringBuilder("x: ");
+        while (sb.length() < 64 * 1024 + 16) {
+            sb.append('a');
+        }
+        sb.append("\r\n\r\nbody\r\n");
+        InputStream in = new ByteArrayInputStream(sb.toString().getBytes(Charsets.US_ASCII));
+        try {
+            parse(MimeConfig.PERMISSIVE, in);
+            Assert.fail("MaxHeaderLengthLimitException expected");
+        } catch (MaxHeaderLengthLimitException expected) {
+            // expected
+        }
+    }
+
     @Test
     public void copyShouldCarryTheLimitsOver() {
         MimeConfig config = MimeConfig.copy(MimeConfig.custom()
                 .setMaxPartCount(7)
                 .setMaxNestingDepth(9)
                 .setMaxTotalHeaderCount(11)
+                .setMaxTotalHeaderLen(13)
                 .build()).build();
         Assert.assertEquals(7, config.getMaxPartCount());
         Assert.assertEquals(9, config.getMaxNestingDepth());
         Assert.assertEquals(11, config.getMaxTotalHeaderCount());
+        Assert.assertEquals(13, config.getMaxTotalHeaderLen());
     }
 }

--- a/core/src/test/java/org/apache/james/mime4j/util/MimeParameterMappingTest.java
+++ b/core/src/test/java/org/apache/james/mime4j/util/MimeParameterMappingTest.java
@@ -1,0 +1,55 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mime4j.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MimeParameterMappingTest {
+
+    @Test
+    public void continuationSegmentsShouldBeConcatenatedInOrder() {
+        MimeParameterMapping mapping = new MimeParameterMapping();
+        mapping.addParameter("filename*0", "abc");
+        mapping.addParameter("filename*1", "def");
+        mapping.addParameter("filename*2", "ghi");
+        Assert.assertEquals("abcdefghi", mapping.get("filename"));
+    }
+
+    @Test
+    public void continuationSegmentsShouldBeReadableRepeatedly() {
+        MimeParameterMapping mapping = new MimeParameterMapping();
+        mapping.addParameter("filename*0", "abc");
+        mapping.addParameter("filename*1", "def");
+        Assert.assertEquals("abcdef", mapping.get("filename"));
+        Assert.assertEquals("abcdef", mapping.get("filename"));
+        Assert.assertEquals("abcdef", mapping.getParameters().get("filename"));
+    }
+
+    @Test(timeout = 15000)
+    public void manyContinuationSegmentsShouldStayLinear() {
+        int segments = 200000;
+        MimeParameterMapping mapping = new MimeParameterMapping();
+        for (int i = 0; i < segments; i++) {
+            mapping.addParameter("filename*" + i, "0123456789");
+        }
+        Assert.assertEquals(segments * 10, mapping.get("filename").length());
+    }
+}

--- a/dom/src/test/java/org/apache/james/mime4j/dom/LargeMessageParsingTest.java
+++ b/dom/src/test/java/org/apache/james/mime4j/dom/LargeMessageParsingTest.java
@@ -22,8 +22,11 @@ package org.apache.james.mime4j.dom;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
+import org.apache.james.mime4j.MimeIOException;
+import org.apache.james.mime4j.io.MaxHeaderLimitException;
 import org.apache.james.mime4j.message.DefaultMessageBuilder;
 import org.apache.james.mime4j.stream.MimeConfig;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class LargeMessageParsingTest {
@@ -31,19 +34,42 @@ public class LargeMessageParsingTest {
     @Test
     public void parsingALargeMessageWithPermissiveConfigShouldSucceed() throws Exception {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream(100 * 1024 * 1024);
-        // 32 * 1.000.000 = ~ 30,5 Mo of headers
-        for (int i = 0; i < 1000000; i++) {
-            outputStream.write(String.format("header: static important value\r\n", i, i).getBytes());
+        // as many headers as the permissive profile allows
+        for (int i = 0; i < MimeConfig.PERMISSIVE.getMaxHeaderCount(); i++) {
+            outputStream.write("header: static important value\r\n".getBytes());
         }
         outputStream.write("\r\n".getBytes());
         // 38 * 1.600.000 = ~ 58 Mo of body
         for (int i = 0; i < 1600000; i++) {
-            outputStream.write(String.format("abcdeghijklmnopqrstuvwxyz0123456789\r\n", i, i).getBytes());
+            outputStream.write("abcdeghijklmnopqrstuvwxyz0123456789\r\n".getBytes());
         }
 
         DefaultMessageBuilder messageBuilder = new DefaultMessageBuilder();
         messageBuilder.setMimeEntityConfig(MimeConfig.PERMISSIVE);
         messageBuilder.parseMessage(new ByteArrayInputStream(outputStream.toByteArray()));
+    }
+
+    @Test
+    public void parsingAHeaderFloodWithPermissiveConfigShouldBeRejected() throws Exception {
+        // A header field costs a handful of bytes on the wire but is retained as an
+        // object graph by the DOM, so an unbounded header count lets a small message
+        // exhaust the heap. MIME4J-269 introduced the permissive profile to be
+        // "very permissive while still denying a single email to use all JVM
+        // memory"; bounding the header count is part of that second half.
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream(32 * 1024 * 1024);
+        for (int i = 0; i < 1000000; i++) {
+            outputStream.write("header: static important value\r\n".getBytes());
+        }
+        outputStream.write("\r\n".getBytes());
+
+        DefaultMessageBuilder messageBuilder = new DefaultMessageBuilder();
+        messageBuilder.setMimeEntityConfig(MimeConfig.PERMISSIVE);
+        try {
+            messageBuilder.parseMessage(new ByteArrayInputStream(outputStream.toByteArray()));
+            Assert.fail("MimeIOException expected");
+        } catch (MimeIOException e) {
+            Assert.assertTrue(e.getCause() instanceof MaxHeaderLimitException);
+        }
     }
 
     @Test

--- a/dom/src/test/java/org/apache/james/mime4j/dom/LargeMessageParsingTest.java
+++ b/dom/src/test/java/org/apache/james/mime4j/dom/LargeMessageParsingTest.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
 import org.apache.james.mime4j.MimeIOException;
+import org.apache.james.mime4j.io.MaxHeaderLengthLimitException;
 import org.apache.james.mime4j.io.MaxHeaderLimitException;
 import org.apache.james.mime4j.message.DefaultMessageBuilder;
 import org.apache.james.mime4j.stream.MimeConfig;
@@ -74,25 +75,26 @@ public class LargeMessageParsingTest {
 
     @Test
     public void parsingAMessageWithLongLinesWithPermissiveConfigShouldSucceed() throws Exception {
-        ByteArrayOutputStream longLineOutputStream = new ByteArrayOutputStream( 1024 * 1024);
-        ByteArrayOutputStream longHeaderOutputStream = new ByteArrayOutputStream( 1024 * 1024);
+        ByteArrayOutputStream longLineOutputStream = new ByteArrayOutputStream(1024 * 1024);
+        ByteArrayOutputStream longHeaderOutputStream = new ByteArrayOutputStream(1024 * 1024);
 
         longHeaderOutputStream.write("header: ".getBytes());
-        // Each header is ~ 500 Ko
-        for (int i = 0; i < 50 * 1024; i++) {
+        // Each header stays just under the permissive per header cap
+        while (longHeaderOutputStream.size() < MimeConfig.PERMISSIVE.getMaxHeaderLen() - 32) {
             longHeaderOutputStream.write("0123456789".getBytes());
         }
         longHeaderOutputStream.write("\r\n".getBytes());
 
-        // Each line is ~ 1Mo
+        // Each line is ~ 1Mo: long lines are still unbounded under the permissive profile
         for (int i = 0; i < 100 * 1024; i++) {
             longLineOutputStream.write("0123456789".getBytes());
         }
         longLineOutputStream.write("\r\n".getBytes());
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream(100 * 1024 * 1024);
-        // 60 * 0.5 = ~ 30 Mo of headers
-        for (int i = 0; i < 60; i++) {
+        // as many ~64 Ko headers as the total header budget allows
+        long headers = MimeConfig.PERMISSIVE.getMaxTotalHeaderLen() / longHeaderOutputStream.size();
+        for (int i = 0; i < headers; i++) {
             outputStream.write(longHeaderOutputStream.toByteArray());
         }
         outputStream.write("\r\n".getBytes());
@@ -104,5 +106,28 @@ public class LargeMessageParsingTest {
         DefaultMessageBuilder messageBuilder = new DefaultMessageBuilder();
         messageBuilder.setMimeEntityConfig(MimeConfig.PERMISSIVE);
         messageBuilder.parseMessage(new ByteArrayInputStream(outputStream.toByteArray()));
+    }
+
+    @Test
+    public void parsingAnOversizedHeaderWithPermissiveConfigShouldBeRejected() throws Exception {
+        // An address, group or parameter list is retained as one object per item, so
+        // a single unbounded header amplifies without limit. 500 Ko in one field used
+        // to be accepted; MIME4J-269's "denying a single email to use all JVM memory"
+        // covers this too.
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream(1024 * 1024);
+        outputStream.write("header: ".getBytes());
+        for (int i = 0; i < 50 * 1024; i++) {
+            outputStream.write("0123456789".getBytes());
+        }
+        outputStream.write("\r\n\r\nbody\r\n".getBytes());
+
+        DefaultMessageBuilder messageBuilder = new DefaultMessageBuilder();
+        messageBuilder.setMimeEntityConfig(MimeConfig.PERMISSIVE);
+        try {
+            messageBuilder.parseMessage(new ByteArrayInputStream(outputStream.toByteArray()));
+            Assert.fail("MimeIOException expected");
+        } catch (MimeIOException e) {
+            Assert.assertTrue(e.getCause() instanceof MaxHeaderLengthLimitException);
+        }
     }
 }

--- a/dom/src/test/java/org/apache/james/mime4j/dom/MessagePartLimitsTest.java
+++ b/dom/src/test/java/org/apache/james/mime4j/dom/MessagePartLimitsTest.java
@@ -1,0 +1,99 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mime4j.dom;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import org.apache.james.mime4j.Charsets;
+import org.apache.james.mime4j.MimeIOException;
+import org.apache.james.mime4j.io.MaxNestingDepthLimitException;
+import org.apache.james.mime4j.io.MaxPartCountLimitException;
+import org.apache.james.mime4j.message.DefaultMessageBuilder;
+import org.apache.james.mime4j.stream.MimeConfig;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Building a DOM allocates an object graph per MIME entity, so a small message
+ * made of a huge number of tiny parts is an amplification vector. These tests
+ * pin down that the message wide entity limits bound that work, including under
+ * {@link MimeConfig#PERMISSIVE} which is what mail servers typically use on
+ * untrusted inbound traffic.
+ */
+public class MessagePartLimitsTest {
+
+    private static InputStream flatMultipart(int count) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Subject: hi\r\n");
+        sb.append("Content-Type: multipart/mixed; boundary=b\r\n\r\n");
+        for (int i = 0; i < count; i++) {
+            sb.append("--b\r\n\r\n");
+        }
+        sb.append("--b--\r\n");
+        return new ByteArrayInputStream(sb.toString().getBytes(Charsets.US_ASCII));
+    }
+
+    private static InputStream nestedMultipart(int depth) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 1; i < depth; i++) {
+            sb.append("Content-Type: multipart/mixed; boundary=b").append(i).append("\r\n\r\n");
+            sb.append("--b").append(i).append("\r\n");
+        }
+        sb.append("\r\n");
+        for (int i = depth - 1; i >= 1; i--) {
+            sb.append("--b").append(i).append("--\r\n");
+        }
+        return new ByteArrayInputStream(sb.toString().getBytes(Charsets.US_ASCII));
+    }
+
+    private static DefaultMessageBuilder builder(MimeConfig config) {
+        DefaultMessageBuilder builder = new DefaultMessageBuilder();
+        builder.setMimeEntityConfig(config);
+        return builder;
+    }
+
+    @Test
+    public void parseMessageShouldRejectTooManyPartsWithPermissiveConfig() throws Exception {
+        try {
+            builder(MimeConfig.PERMISSIVE).parseMessage(flatMultipart(50000));
+            Assert.fail("MimeIOException expected");
+        } catch (MimeIOException e) {
+            Assert.assertTrue(e.getCause() instanceof MaxPartCountLimitException);
+        }
+    }
+
+    @Test
+    public void parseMessageShouldRejectTooDeeplyNestedPartsWithPermissiveConfig() throws Exception {
+        MimeConfig config = MimeConfig.copy(MimeConfig.PERMISSIVE).setMaxPartCount(-1).build();
+        try {
+            builder(config).parseMessage(nestedMultipart(5000));
+            Assert.fail("MimeIOException expected");
+        } catch (MimeIOException e) {
+            Assert.assertTrue(e.getCause() instanceof MaxNestingDepthLimitException);
+        }
+    }
+
+    @Test
+    public void parseMessageShouldAcceptAMessageWithinTheLimits() throws Exception {
+        Message message = builder(MimeConfig.PERMISSIVE).parseMessage(flatMultipart(512));
+        Assert.assertEquals(512, ((Multipart) message.getBody()).getCount());
+    }
+}


### PR DESCRIPTION
I did run performance test and did not notice significant performance drop.